### PR TITLE
fix: Switched model to eval mode in example

### DIFF
--- a/scripts/cam_example.py
+++ b/scripts/cam_example.py
@@ -41,7 +41,7 @@ def main(args):
     device = torch.device(args.device)
 
     # Pretrained imagenet model
-    model = models.__dict__[args.model](pretrained=True).to(device=device)
+    model = models.__dict__[args.model](pretrained=True).eval().to(device=device)
     conv_layer = MODEL_CONFIG[args.model]['conv_layer']
     input_layer = MODEL_CONFIG[args.model]['input_layer']
     fc_layer = MODEL_CONFIG[args.model]['fc_layer']


### PR DESCRIPTION
This PR switches the model to eval mode in the example script, as suggested by #14.