### PR TITLE
fix: Support CAM for intermediate layers

### DIFF
--- a/test/test_cams.py
+++ b/test/test_cams.py
@@ -77,11 +77,35 @@ class Tester(unittest.TestCase):
 
         self._test_extractor(extractor, model)
 
+    def _test_cam_arbitrary_layer(self, name):
+        """ Test CAM computation for an arbitrary intermediate layer """
+
+        model = resnet18(pretrained=True).eval()
+        conv_layer = 'layer4.1.relu'
+        input_layer = 'conv1'
+        fc_layer = 'fc'
+
+        # Hook the corresponding layer in the model
+        extractor = cams.__dict__[name](model, conv_layer, fc_layer if name == 'CAM' else input_layer)
+
+        self._test_extractor(extractor, model)
+
     def _test_gradcam(self, name):
 
         # Get a pretrained model
         model = mobilenet_v2(pretrained=True)
         conv_layer = 'features'
+
+        # Hook the corresponding layer in the model
+        extractor = cams.__dict__[name](model, conv_layer)
+
+        self._test_extractor(extractor, model)
+
+    def _test_gradcam_arbitrary_layer(self, name):
+        """ Test GradCAM computation for an arbitrary intermediate layer """
+
+        model = mobilenet_v2(pretrained=True)
+        conv_layer = 'features.17.conv.3'
 
         # Hook the corresponding layer in the model
         extractor = cams.__dict__[name](model, conv_layer)
@@ -104,6 +128,7 @@ class Tester(unittest.TestCase):
 for cam_extractor in ['CAM', 'ScoreCAM', 'SSCAM', 'ISSCAM']:
     def do_test(self, cam_extractor=cam_extractor):
         self._test_cam(cam_extractor)
+        self._test_cam_arbitrary_layer(cam_extractor)
 
     setattr(Tester, "test_" + cam_extractor.lower(), do_test)
 
@@ -111,6 +136,7 @@ for cam_extractor in ['CAM', 'ScoreCAM', 'SSCAM', 'ISSCAM']:
 for cam_extractor in ['GradCAM', 'GradCAMpp']:
     def do_test(self, cam_extractor=cam_extractor):
         self._test_gradcam(cam_extractor)
+        self._test_gradcam_arbitrary_layer(cam_extractor)
 
     setattr(Tester, "test_" + cam_extractor.lower(), do_test)
 

--- a/test/test_cams.py
+++ b/test/test_cams.py
@@ -78,7 +78,7 @@ class Tester(unittest.TestCase):
         self._test_extractor(extractor, model)
 
     def _test_cam_arbitrary_layer(self, name):
-        
+
         model = resnet18(pretrained=True).eval()
         conv_layer = 'layer4.1.relu'
         input_layer = 'conv1'
@@ -101,7 +101,7 @@ class Tester(unittest.TestCase):
         self._test_extractor(extractor, model)
 
     def _test_gradcam_arbitrary_layer(self, name):
-        
+
         model = mobilenet_v2(pretrained=True)
         conv_layer = 'features.17.conv.3'
 

--- a/test/test_cams.py
+++ b/test/test_cams.py
@@ -79,7 +79,7 @@ class Tester(unittest.TestCase):
 
     def _test_cam_arbitrary_layer(self, name):
 
-        model = resnet18(pretrained=True).eval()
+        model = resnet18(pretrained=False).eval()
         conv_layer = 'layer4.1.relu'
         input_layer = 'conv1'
         fc_layer = 'fc'
@@ -102,7 +102,7 @@ class Tester(unittest.TestCase):
 
     def _test_gradcam_arbitrary_layer(self, name):
 
-        model = mobilenet_v2(pretrained=True)
+        model = mobilenet_v2(pretrained=False)
         conv_layer = 'features.17.conv.3'
 
         # Hook the corresponding layer in the model

--- a/test/test_cams.py
+++ b/test/test_cams.py
@@ -78,7 +78,7 @@ class Tester(unittest.TestCase):
         self._test_extractor(extractor, model)
 
     def _test_cam_arbitrary_layer(self, name):
-        """ Test CAM computation for an arbitrary intermediate layer """
+        
         model = resnet18(pretrained=True).eval()
         conv_layer = 'layer4.1.relu'
         input_layer = 'conv1'
@@ -101,7 +101,7 @@ class Tester(unittest.TestCase):
         self._test_extractor(extractor, model)
 
     def _test_gradcam_arbitrary_layer(self, name):
-        """ Test GradCAM computation for an arbitrary intermediate layer """
+        
         model = mobilenet_v2(pretrained=True)
         conv_layer = 'features.17.conv.3'
 

--- a/test/test_cams.py
+++ b/test/test_cams.py
@@ -79,7 +79,6 @@ class Tester(unittest.TestCase):
 
     def _test_cam_arbitrary_layer(self, name):
         """ Test CAM computation for an arbitrary intermediate layer """
-
         model = resnet18(pretrained=True).eval()
         conv_layer = 'layer4.1.relu'
         input_layer = 'conv1'
@@ -103,7 +102,6 @@ class Tester(unittest.TestCase):
 
     def _test_gradcam_arbitrary_layer(self, name):
         """ Test GradCAM computation for an arbitrary intermediate layer """
-
         model = mobilenet_v2(pretrained=True)
         conv_layer = 'features.17.conv.3'
 

--- a/torchcam/cams/cam.py
+++ b/torchcam/cams/cam.py
@@ -25,11 +25,16 @@ class _CAM:
         conv_layer: str
     ) -> None:
 
-        if not hasattr(model, conv_layer):
+        # Obtain a mapping from module name to module instance for each layer in the model
+        self.model_module_dict = {}
+        for name, module in model.named_modules():
+            self.model_module_dict[name] = module
+
+        if conv_layer not in self.model_module_dict.keys():
             raise ValueError(f"Unable to find submodule {conv_layer} in the model")
         self.model = model
         # Forward hook
-        self.hook_handles.append(self.model._modules.get(conv_layer).register_forward_hook(self._hook_a))
+        self.hook_handles.append(self.model_module_dict[conv_layer].register_forward_hook(self._hook_a))
         # Enable hooks
         self._hooks_enabled = True
         # Should ReLU be used before normalization
@@ -154,7 +159,7 @@ class CAM(_CAM):
 
         super().__init__(model, conv_layer)
         # Softmax weight
-        self._fc_weights = self.model._modules.get(fc_layer).weight.data
+        self._fc_weights = self.model_module_dict[fc_layer].weight.data
 
     def _get_weights(self, class_idx: int, scores: Optional[Tensor] = None) -> Tensor:
         """Computes the weight coefficients of the hooked activation maps"""
@@ -214,7 +219,7 @@ class ScoreCAM(_CAM):
         super().__init__(model, conv_layer)
 
         # Input hook
-        self.hook_handles.append(self.model._modules.get(input_layer).register_forward_pre_hook(self._store_input))
+        self.hook_handles.append(self.model_module_dict[input_layer].register_forward_pre_hook(self._store_input))
         self.bs = batch_size
         # Ensure ReLU is applied to CAM before normalization
         self._relu = True

--- a/torchcam/cams/gradcam.py
+++ b/torchcam/cams/gradcam.py
@@ -29,7 +29,7 @@ class _GradCAM(_CAM):
         # Model output is used by the extractor
         self._score_used = True
         # Backward hook
-        self.hook_handles.append(self.model_module_dict[conv_layer].register_backward_hook(self._hook_g))
+        self.hook_handles.append(self.submodule_dict[conv_layer].register_backward_hook(self._hook_g))
 
     def _hook_g(self, module: torch.nn.Module, input: Tensor, output: Tensor) -> None:
         """Gradient hook"""
@@ -214,7 +214,7 @@ class SmoothGradCAMpp(_GradCAM):
         self._score_used = False
 
         # Input hook
-        self.hook_handles.append(self.model_module_dict[first_layer].register_forward_pre_hook(self._store_input))
+        self.hook_handles.append(self.submodule_dict[first_layer].register_forward_pre_hook(self._store_input))
         # Noise distribution
         self.num_samples = num_samples
         self.std = std

--- a/torchcam/cams/gradcam.py
+++ b/torchcam/cams/gradcam.py
@@ -29,7 +29,7 @@ class _GradCAM(_CAM):
         # Model output is used by the extractor
         self._score_used = True
         # Backward hook
-        self.hook_handles.append(self.model._modules.get(conv_layer).register_backward_hook(self._hook_g))
+        self.hook_handles.append(self.model_module_dict[conv_layer].register_backward_hook(self._hook_g))
 
     def _hook_g(self, module: torch.nn.Module, input: Tensor, output: Tensor) -> None:
         """Gradient hook"""
@@ -214,7 +214,7 @@ class SmoothGradCAMpp(_GradCAM):
         self._score_used = False
 
         # Input hook
-        self.hook_handles.append(self.model._modules.get(first_layer).register_forward_pre_hook(self._store_input))
+        self.hook_handles.append(self.model_module_dict[first_layer].register_forward_pre_hook(self._store_input))
         # Noise distribution
         self.num_samples = num_samples
         self.std = std


### PR DESCRIPTION
Add support to compute CAM for any intermediate layer that is not necessarily a top level attribute of the model. For example, layers defined within a nn.Sequential block are not directly accessible by model._modules.get() and there does not seem to be a straight forward way to get CAMs for such layers.
I found use cases where this is needed; I think this might be generic enough to be included in the package.
Do let me know if there is a better way to achieve this. Thanks!