### PR TITLE
fix: Fixed hooking mechanism

### DIFF
--- a/scripts/cam_example.py
+++ b/scripts/cam_example.py
@@ -61,8 +61,13 @@ def main(args):
                       ScoreCAM(model, conv_layer, input_layer), SSCAM(model, conv_layer, input_layer),
                       ISSCAM(model, conv_layer, input_layer)]
 
+    # Don't trigger all hooks
+    for extractor in cam_extractors:
+        extractor._hooks_enabled = False
+
     fig, axes = plt.subplots(1, len(cam_extractors), figsize=(7, 2))
     for idx, extractor in enumerate(cam_extractors):
+        extractor._hooks_enabled = True
         model.zero_grad()
         scores = model(img_tensor.unsqueeze(0))
 
@@ -73,6 +78,7 @@ def main(args):
         activation_map = extractor(class_idx, scores).cpu()
         # Clean data
         extractor.clear_hooks()
+        extractor._hooks_enabled = False
         # Convert it to PIL image
         # The indexing below means first image in batch
         heatmap = to_pil_image(activation_map, mode='F')

--- a/torchcam/cams/cam.py
+++ b/torchcam/cams/cam.py
@@ -16,9 +16,6 @@ class _CAM:
         conv_layer: name of the last convolutional layer
     """
 
-    hook_a: Optional[Tensor] = None
-    hook_handles: List[torch.utils.hooks.RemovableHandle] = []
-
     def __init__(
         self,
         model: nn.Module,
@@ -28,6 +25,9 @@ class _CAM:
         if not hasattr(model, conv_layer):
             raise ValueError(f"Unable to find submodule {conv_layer} in the model")
         self.model = model
+        # Init hooks
+        self.hook_a: Optional[Tensor] = None
+        self.hook_handles: List[torch.utils.hooks.RemovableHandle] = []
         # Forward hook
         self.hook_handles.append(self.model._modules.get(conv_layer).register_forward_hook(self._hook_a))
         # Enable hooks
@@ -145,15 +145,12 @@ class CAM(_CAM):
         fc_layer: name of the fully convolutional layer
     """
 
-    hook_a: Optional[Tensor] = None
-    hook_handles: List[torch.utils.hooks.RemovableHandle] = []
-
     def __init__(
         self,
         model: nn.Module,
         conv_layer: str,
         fc_layer: str
-    ):
+    ) -> None:
 
         super().__init__(model, conv_layer)
         # Softmax weight
@@ -206,9 +203,6 @@ class ScoreCAM(_CAM):
         batch_size: batch size used to forward masked inputs
     """
 
-    hook_a: Optional[Tensor] = None
-    hook_handles: List[torch.utils.hooks.RemovableHandle] = []
-
     def __init__(
         self,
         model: nn.Module,
@@ -225,7 +219,7 @@ class ScoreCAM(_CAM):
         # Ensure ReLU is applied to CAM before normalization
         self._relu = True
 
-    def _store_input(self, module: nn.Module, input: Tensor):
+    def _store_input(self, module: nn.Module, input: Tensor) -> None:
         """Store model input tensor"""
 
         if self._hooks_enabled:
@@ -312,9 +306,6 @@ class SSCAM(ScoreCAM):
         num_samples: number of noisy samples used for weight computation
         std: standard deviation of the noise added to the normalized activation
     """
-
-    hook_a: Optional[Tensor] = None
-    hook_handles: List[torch.utils.hooks.RemovableHandle] = []
 
     def __init__(
         self,
@@ -419,9 +410,6 @@ class ISSCAM(ScoreCAM):
         batch_size: batch size used to forward masked inputs
         num_samples: number of noisy samples used for weight computation
     """
-
-    hook_a: Optional[Tensor] = None
-    hook_handles: List[torch.utils.hooks.RemovableHandle] = []
 
     def __init__(
         self,

--- a/torchcam/cams/cam.py
+++ b/torchcam/cams/cam.py
@@ -145,6 +145,9 @@ class CAM(_CAM):
         fc_layer: name of the fully convolutional layer
     """
 
+    hook_a: Optional[Tensor] = None
+    hook_handles: List[torch.utils.hooks.RemovableHandle] = []
+
     def __init__(
         self,
         model: nn.Module,
@@ -202,6 +205,9 @@ class ScoreCAM(_CAM):
         input_layer: name of the first layer
         batch_size: batch size used to forward masked inputs
     """
+
+    hook_a: Optional[Tensor] = None
+    hook_handles: List[torch.utils.hooks.RemovableHandle] = []
 
     def __init__(
         self,
@@ -307,6 +313,9 @@ class SSCAM(ScoreCAM):
         std: standard deviation of the noise added to the normalized activation
     """
 
+    hook_a: Optional[Tensor] = None
+    hook_handles: List[torch.utils.hooks.RemovableHandle] = []
+
     def __init__(
         self,
         model: nn.Module,
@@ -410,6 +419,9 @@ class ISSCAM(ScoreCAM):
         batch_size: batch size used to forward masked inputs
         num_samples: number of noisy samples used for weight computation
     """
+
+    hook_a: Optional[Tensor] = None
+    hook_handles: List[torch.utils.hooks.RemovableHandle] = []
 
     def __init__(
         self,

--- a/torchcam/cams/gradcam.py
+++ b/torchcam/cams/gradcam.py
@@ -1,6 +1,6 @@
 import torch
 from torch import Tensor
-from typing import Optional
+from typing import Optional, List
 
 from .cam import _CAM
 
@@ -84,6 +84,10 @@ class GradCAM(_GradCAM):
         conv_layer: name of the last convolutional layer
     """
 
+    hook_a: Optional[Tensor] = None
+    hook_g: Optional[Tensor] = None
+    hook_handles: List[torch.utils.hooks.RemovableHandle] = []
+
     def _get_weights(self, class_idx: int, scores: Tensor) -> Tensor:  # type: ignore[override]
         """Computes the weight coefficients of the hooked activation maps"""
 
@@ -134,6 +138,10 @@ class GradCAMpp(_GradCAM):
         model: input model
         conv_layer: name of the last convolutional layer
     """
+
+    hook_a: Optional[Tensor] = None
+    hook_g: Optional[Tensor] = None
+    hook_handles: List[torch.utils.hooks.RemovableHandle] = []
 
     def _get_weights(self, class_idx: int, scores: Tensor) -> Tensor:  # type: ignore[override]
         """Computes the weight coefficients of the hooked activation maps"""
@@ -199,6 +207,10 @@ class SmoothGradCAMpp(_GradCAM):
         model: input model
         conv_layer: name of the last convolutional layer
     """
+
+    hook_a: Optional[Tensor] = None
+    hook_g: Optional[Tensor] = None
+    hook_handles: List[torch.utils.hooks.RemovableHandle] = []
 
     def __init__(
         self,

--- a/torchcam/cams/gradcam.py
+++ b/torchcam/cams/gradcam.py
@@ -1,6 +1,6 @@
 import torch
 from torch import Tensor
-from typing import Optional, List
+from typing import Optional
 
 from .cam import _CAM
 

--- a/torchcam/cams/gradcam.py
+++ b/torchcam/cams/gradcam.py
@@ -15,8 +15,6 @@ class _GradCAM(_CAM):
         conv_layer: name of the last convolutional layer
     """
 
-    hook_g: Optional[Tensor] = None
-
     def __init__(
         self,
         model: torch.nn.Module,
@@ -24,6 +22,8 @@ class _GradCAM(_CAM):
     ) -> None:
 
         super().__init__(model, conv_layer)
+        # Init hook
+        self.hook_g: Optional[Tensor] = None
         # Ensure ReLU is applied before normalization
         self._relu = True
         # Model output is used by the extractor
@@ -84,10 +84,6 @@ class GradCAM(_GradCAM):
         conv_layer: name of the last convolutional layer
     """
 
-    hook_a: Optional[Tensor] = None
-    hook_g: Optional[Tensor] = None
-    hook_handles: List[torch.utils.hooks.RemovableHandle] = []
-
     def _get_weights(self, class_idx: int, scores: Tensor) -> Tensor:  # type: ignore[override]
         """Computes the weight coefficients of the hooked activation maps"""
 
@@ -138,10 +134,6 @@ class GradCAMpp(_GradCAM):
         model: input model
         conv_layer: name of the last convolutional layer
     """
-
-    hook_a: Optional[Tensor] = None
-    hook_g: Optional[Tensor] = None
-    hook_handles: List[torch.utils.hooks.RemovableHandle] = []
 
     def _get_weights(self, class_idx: int, scores: Tensor) -> Tensor:  # type: ignore[override]
         """Computes the weight coefficients of the hooked activation maps"""
@@ -207,10 +199,6 @@ class SmoothGradCAMpp(_GradCAM):
         model: input model
         conv_layer: name of the last convolutional layer
     """
-
-    hook_a: Optional[Tensor] = None
-    hook_g: Optional[Tensor] = None
-    hook_handles: List[torch.utils.hooks.RemovableHandle] = []
 
     def __init__(
         self,


### PR DESCRIPTION
This PR fixes hook handle sharing between CAMs. This issue can only be encountered if you loop on different cam extractors and was reported in #22. Additionally, the PR optimizes memory usage in the example script.

This will close #22  