### PR TITLE
chore: Removed pytorch upper bound constraint in conda

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - python>=3.6
 
   run:
-    - pytorch >=1.1.0, <=1.4.0
+    - pytorch >=1.1.0
     - numpy
     - pillow
     - matplotlib


### PR DESCRIPTION
This PR removes the upper bound version constraint on pytorch of the conda build. The constraint was a temporary fix on a legacy version which is no longer relevant.

Successfully merging this will close #27 