### PR TITLE
refactor: Renamed ISSCAM into ISCAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ This project is developed and maintained by the repo owner, but the implementati
 - [Smooth Grad-CAM++](https://arxiv.org/abs/1908.01224): SmoothGrad mechanism coupled with GradCAM.
 - [Score-CAM](https://arxiv.org/abs/1910.01279): score-weighting of class activation for better interpretability.
 - [SS-CAM](https://arxiv.org/abs/2006.14255): SmoothGrad mechanism coupled with Score-CAM.
+- [IS-CAM](https://arxiv.org/abs/2010.03023): integration-based variant of Score-CAM.
 
 
 

--- a/docs/source/cams.rst
+++ b/docs/source/cams.rst
@@ -16,7 +16,7 @@ Methods related to activation-based class activation maps.
 
 .. autoclass:: SSCAM
 
-.. autoclass:: ISSCAM
+.. autoclass:: ISCAM
 
 
 Grad-CAM

--- a/scripts/cam_example.py
+++ b/scripts/cam_example.py
@@ -15,7 +15,7 @@ import torch
 from torchvision import models
 from torchvision.transforms.functional import normalize, resize, to_tensor, to_pil_image
 
-from torchcam.cams import CAM, GradCAM, GradCAMpp, SmoothGradCAMpp, ScoreCAM, SSCAM, ISSCAM
+from torchcam.cams import CAM, GradCAM, GradCAMpp, SmoothGradCAMpp, ScoreCAM, SSCAM, ISCAM
 from torchcam.utils import overlay_mask
 
 VGG_CONFIG = {_vgg: dict(input_layer='features', conv_layer='features')

--- a/scripts/cam_example.py
+++ b/scripts/cam_example.py
@@ -59,7 +59,7 @@ def main(args):
     cam_extractors = [CAM(model, conv_layer, fc_layer), GradCAM(model, conv_layer),
                       GradCAMpp(model, conv_layer), SmoothGradCAMpp(model, conv_layer, input_layer),
                       ScoreCAM(model, conv_layer, input_layer), SSCAM(model, conv_layer, input_layer),
-                      ISSCAM(model, conv_layer, input_layer)]
+                      ISCAM(model, conv_layer, input_layer)]
 
     # Don't trigger all hooks
     for extractor in cam_extractors:

--- a/test/test_cams.py
+++ b/test/test_cams.py
@@ -123,7 +123,7 @@ class Tester(unittest.TestCase):
         self._test_extractor(extractor, model)
 
 
-for cam_extractor in ['CAM', 'ScoreCAM', 'SSCAM', 'ISSCAM']:
+for cam_extractor in ['CAM', 'ScoreCAM', 'SSCAM', 'ISCAM']:
     def do_test(self, cam_extractor=cam_extractor):
         self._test_cam(cam_extractor)
         self._test_cam_arbitrary_layer(cam_extractor)

--- a/torchcam/cams/cam.py
+++ b/torchcam/cams/cam.py
@@ -5,7 +5,7 @@ from torch import nn
 import torch.nn.functional as F
 from typing import Optional, List
 
-__all__ = ['CAM', 'ScoreCAM', 'SSCAM', 'ISSCAM']
+__all__ = ['CAM', 'ScoreCAM', 'SSCAM', 'ISCAM']
 
 
 class _CAM:
@@ -370,9 +370,9 @@ class SSCAM(ScoreCAM):
         return f"{self.__class__.__name__}(batch_size={self.bs}, num_samples={self.num_samples}, std={self.std})"
 
 
-class ISSCAM(ScoreCAM):
-    """Implements a variant of Score-CAM, based on Rakshit Naidu's `work
-    <https://github.com/r0cketr1kky/ISS-CAM_resources>`_.
+class ISCAM(ScoreCAM):
+    """Implements a class activation map extractor as described in `"IS-CAM: Integrated Score-CAM for axiomatic-based
+    explanations" <https://arxiv.org/pdf/2010.03023.pdf>`_.
 
     The localization map is computed as follows:
 
@@ -402,7 +402,7 @@ class ISSCAM(ScoreCAM):
         >>> from torchvision.models import resnet18
         >>> from torchcam.cams import ISSCAM
         >>> model = resnet18(pretrained=True).eval()
-        >>> cam = ISSCAM(model, 'layer4', 'conv1')
+        >>> cam = ISCAM(model, 'layer4', 'conv1')
         >>> with torch.no_grad(): out = model(input_tensor)
         >>> cam(class_idx=100)
 


### PR DESCRIPTION
Following on the publication of the corresponding paper, the ISSCAM was renamed into ISCAM.