### PR TITLE
fix: Fixed example script and added NaN checks

### DIFF
--- a/scripts/cam_example.py
+++ b/scripts/cam_example.py
@@ -41,7 +41,7 @@ def main(args):
     device = torch.device(args.device)
 
     # Pretrained imagenet model
-    model = models.__dict__[args.model](pretrained=True).eval().to(device=device)
+    model = models.__dict__[args.model](pretrained=True).to(device=device)
     conv_layer = MODEL_CONFIG[args.model]['conv_layer']
     fc_layer = MODEL_CONFIG[args.model]['fc_layer']
 

--- a/test/test_cams.py
+++ b/test/test_cams.py
@@ -16,6 +16,7 @@ class CAMCoreTester(unittest.TestCase):
         # Simple verifications
         self.assertIsInstance(cam, torch.Tensor)
         self.assertEqual(cam.shape, (7, 7))
+        self.assertFalse(torch.any(torch.isnan(cam)))
 
     @staticmethod
     def _get_img_tensor():


### PR DESCRIPTION
This PR introduces the following modifications:
- fixed the example script by removing the `.eval()` mode
- added NaNs check in unittests
- fixed gradient underflow in GradCAMpp that produced some NaNs

Successfully merging this PR will close #36 