### PR TITLE
docs: Fixed doc building requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-sphinx
+sphinx<=3.4.3
 sphinx-rtd-theme==0.4.3


### PR DESCRIPTION
This PR fixes the issues with sphinx arising with version 3.5.0, while https://github.com/sphinx-doc/sphinx/issues/8885 is not fixed