### PR TITLE
fix: Fixed doc building

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -29,6 +29,7 @@ function deploy_doc(){
 # You can find the commit for each tag on https://github.com/frgfm/torch-cam/tags
 if [ -d build ]; then rm -Rf build; fi
 cp -r source/_static .
+git fetch
 deploy_doc "" latest
 deploy_doc "7be0b4f" v0.1.0
 deploy_doc "a95d680" v0.1.1

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -11,7 +11,7 @@ function deploy_doc(){
         if [ "$2" == "latest" ]; then
             echo "Pushing master"
             sphinx-build source _build -a && mkdir build && mkdir build/$2 && cp -a _build/* build/$2/
-        elif [ -d build/$2 ]; then
+        elif ssh -oStrictHostKeyChecking=no $doc "[ -d build/$2 ]"; then
             echo "Directory" $2 "already exists"
         else
             echo "Pushing version" $2

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -11,7 +11,7 @@ function deploy_doc(){
         if [ "$2" == "latest" ]; then
             echo "Pushing master"
             sphinx-build source _build -a && mkdir build && mkdir build/$2 && cp -a _build/* build/$2/
-        elif ssh -oStrictHostKeyChecking=no $doc "[ -d build/$2 ]"; then
+        elif [ -d build/$2 ]; then
             echo "Directory" $2 "already exists"
         else
             echo "Pushing version" $2


### PR DESCRIPTION
This PR introduces the following modifications:
- added git fetch before the multiple checkouts to avoid issues with CI

This allows the CI to build the documentation for previous releases (currently it wrongly labels builds from the same commit)