### PR TITLE
fix: Fixed backward hook for torch>=1.8.0

### DIFF
--- a/test/test_cams_gradcam.py
+++ b/test/test_cams_gradcam.py
@@ -17,8 +17,8 @@ def _verify_cam(activation_map, output_size):
     [
         ["GradCAM", 'features.18.0', (7, 7)],
         ["GradCAMpp", 'features.18.0', (7, 7)],
-        ["SmoothGradCAMpp", None, (7, 7)],
-        ["XGradCAM", None, (7, 7)],
+        ["SmoothGradCAMpp", 'features.18.0', (7, 7)],
+        ["XGradCAM", 'features.18.0', (7, 7)],
     ],
 )
 def test_img_cams(cam_name, target_layer, output_size, mock_img_tensor):

--- a/torchcam/cams/gradcam.py
+++ b/torchcam/cams/gradcam.py
@@ -30,8 +30,10 @@ class _GradCAM(_CAM):
         self._relu = True
         # Model output is used by the extractor
         self._score_used = True
+        # cf. https://github.com/pytorch/pytorch/pull/46163
+        bw_hook = 'register_full_backward_hook' if torch.__version__ >= '1.8.0' else 'register_backward_hook'
         # Backward hook
-        self.hook_handles.append(self.submodule_dict[self.target_layer].register_backward_hook(self._hook_g))
+        self.hook_handles.append(getattr(self.submodule_dict[self.target_layer], bw_hook)(self._hook_g))
 
     def _hook_g(self, module: torch.nn.Module, input: Tensor, output: Tensor) -> None:
         """Gradient hook"""


### PR DESCRIPTION
Following up on https://github.com/pytorch/pytorch/pull/46163, this PR introduces the following modifications:
- adds a dynamic check on `torch` version to determine the backward hook version
- fixed the numerous warnings in gradient-based CAM for torch>=1.8.0 by replacing the legacy hook when possible

Resolves #48