### PR TITLE
fix: Fixed gradient-based CAMs for architectures with inplace ops

### DIFF
--- a/scripts/cam_example.py
+++ b/scripts/cam_example.py
@@ -53,11 +53,7 @@ def main(args):
             'XGradCAM', 'LayerCAM'
         ]
     # Hook the corresponding layer in the model
-    cam_extractors = [cams.__dict__[name](model) for name in methods]
-
-    # Don't trigger all hooks
-    for extractor in cam_extractors:
-        extractor._hooks_enabled = False
+    cam_extractors = [cams.__dict__[name](model, enable_hooks=False) for name in methods]
 
     # Homogenize number of elements in each row
     num_cols = math.ceil((len(cam_extractors) + 1) / args.rows)

--- a/scripts/cam_example.py
+++ b/scripts/cam_example.py
@@ -117,7 +117,7 @@ if __name__ == '__main__':
     parser.add_argument("--device", type=str, default=None, help='Default device to perform computation on')
     parser.add_argument("--savefig", type=str, default=None, help="Path to save figure")
     parser.add_argument("--method", type=str, default=None, help="CAM method to use")
-    parser.add_argument("--alpha", type=float, default=0.7, help="Transparency of the heatmap")
+    parser.add_argument("--alpha", type=float, default=0.5, help="Transparency of the heatmap")
     parser.add_argument("--rows", type=int, default=1, help="Number of rows for the layout")
     parser.add_argument("--noblock", dest="noblock", help="Disables blocking visualization", action="store_true")
     args = parser.parse_args()

--- a/torchcam/cams/cam.py
+++ b/torchcam/cams/cam.py
@@ -9,7 +9,7 @@ import torch
 from torch import Tensor
 from torch import nn
 import torch.nn.functional as F
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Any
 
 from .core import _CAM
 from .utils import locate_linear_layer
@@ -53,9 +53,10 @@ class CAM(_CAM):
         target_layer: Optional[str] = None,
         fc_layer: Optional[str] = None,
         input_shape: Tuple[int, ...] = (3, 224, 224),
+        **kwargs: Any,
     ) -> None:
 
-        super().__init__(model, target_layer, input_shape)
+        super().__init__(model, target_layer, input_shape, **kwargs)
 
         # If the layer is not specified, try automatic resolution
         if fc_layer is None:
@@ -124,9 +125,10 @@ class ScoreCAM(_CAM):
         target_layer: Optional[str] = None,
         batch_size: int = 32,
         input_shape: Tuple[int, ...] = (3, 224, 224),
+        **kwargs: Any,
     ) -> None:
 
-        super().__init__(model, target_layer, input_shape)
+        super().__init__(model, target_layer, input_shape, **kwargs)
 
         # Input hook
         self.hook_handles.append(model.register_forward_pre_hook(self._store_input))
@@ -237,9 +239,10 @@ class SSCAM(ScoreCAM):
         num_samples: int = 35,
         std: float = 2.0,
         input_shape: Tuple[int, ...] = (3, 224, 224),
+        **kwargs: Any,
     ) -> None:
 
-        super().__init__(model, target_layer, batch_size, input_shape)
+        super().__init__(model, target_layer, batch_size, input_shape, **kwargs)
 
         self.num_samples = num_samples
         self.std = std
@@ -347,9 +350,10 @@ class ISCAM(ScoreCAM):
         batch_size: int = 32,
         num_samples: int = 10,
         input_shape: Tuple[int, ...] = (3, 224, 224),
+        **kwargs: Any,
     ) -> None:
 
-        super().__init__(model, target_layer, batch_size, input_shape)
+        super().__init__(model, target_layer, batch_size, input_shape, **kwargs)
 
         self.num_samples = num_samples
 

--- a/torchcam/cams/core.py
+++ b/torchcam/cams/core.py
@@ -22,6 +22,7 @@ class _CAM:
         model: input model
         target_layer: name of the target layer
         input_shape: shape of the expected input tensor excluding the batch dimension
+        enable_hooks: should hooks be enabled by default
     """
 
     def __init__(
@@ -29,6 +30,7 @@ class _CAM:
         model: nn.Module,
         target_layer: Optional[str] = None,
         input_shape: Tuple[int, ...] = (3, 224, 224),
+        enable_hooks: bool = True,
     ) -> None:
 
         # Obtain a mapping from module name to module instance for each layer in the model
@@ -53,7 +55,7 @@ class _CAM:
         # Forward hook
         self.hook_handles.append(self.submodule_dict[target_layer].register_forward_hook(self._hook_a))
         # Enable hooks
-        self._hooks_enabled = True
+        self._hooks_enabled = enable_hooks
         # Should ReLU be used before normalization
         self._relu = False
         # Model output is used by the extractor


### PR DESCRIPTION
Following up on #72, this PR introduces the following modifications:
- uses the trick suggested in https://github.com/pytorch/pytorch/issues/61519 to hook the output tensor in order to retrieve its grad on the backward pass
- extended unittests for gradient-based methods to a small model with in place ReLU
- updated example script to accommodate new grad hook registration
- added option to disable hooks by default in CAM constructors

Resolves #72