### PR TITLE
target_layer can be a nn.Module

### DIFF
--- a/test/test_cams_cam.py
+++ b/test/test_cams_cam.py
@@ -11,7 +11,7 @@ from torchcam.cams import cam
 
 
 def _verify_cam(activation_map, output_size):
-    # Simple verifications
+    #  Simple verifications
     assert isinstance(activation_map, torch.Tensor)
     assert activation_map.shape == output_size
     assert not torch.any(torch.isnan(activation_map))
@@ -21,9 +21,10 @@ def _verify_cam(activation_map, output_size):
     "cam_name, target_layer, num_samples, output_size",
     [
         ["CAM", None, None, (7, 7)],
-        ["ScoreCAM", 'features.16.conv.3', None, (7, 7)],
-        ["SSCAM", 'features.16.conv.3', 4, (7, 7)],
-        ["ISCAM", 'features.16.conv.3', 4, (7, 7)],
+        ["ScoreCAM", "features.16.conv.3", None, (7, 7)],
+        ["ScoreCAM", lambda m: m.features, None, (7, 7)],
+        ["SSCAM", "features.16.conv.3", 4, (7, 7)],
+        ["ISCAM", "features.16.conv.3", 4, (7, 7)],
     ],
 )
 def test_img_cams(cam_name, target_layer, num_samples, output_size, mock_img_tensor):
@@ -31,9 +32,10 @@ def test_img_cams(cam_name, target_layer, num_samples, output_size, mock_img_ten
     kwargs = {}
     # Speed up testing by reducing the number of samples
     if isinstance(num_samples, int):
-        kwargs['num_samples'] = num_samples
+        kwargs["num_samples"] = num_samples
 
     # Hook the corresponding layer in the model
+    target_layer = target_layer(model) if callable(target_layer) else target_layer
     extractor = cam.__dict__[cam_name](model, target_layer, **kwargs)
 
     with torch.no_grad():
@@ -43,7 +45,7 @@ def test_img_cams(cam_name, target_layer, num_samples, output_size, mock_img_ten
 
 
 def test_cam_conv1x1(mock_fullyconv_model):
-    extractor = cam.CAM(mock_fullyconv_model, fc_layer='1')
+    extractor = cam.CAM(mock_fullyconv_model, fc_layer="1")
     with torch.no_grad():
         scores = mock_fullyconv_model(torch.rand((1, 3, 32, 32)))
         # Use the hooked data to compute activation map
@@ -53,18 +55,25 @@ def test_cam_conv1x1(mock_fullyconv_model):
 @pytest.mark.parametrize(
     "cam_name, target_layer, num_samples, output_size",
     [
-        ["CAM", '0.3', None, (8, 16, 16)],
-        ["ScoreCAM", '0.3', None, (8, 16, 16)],
-        ["SSCAM", '0.3', 4, (8, 16, 16)],
-        ["ISCAM", '0.3', 4, (8, 16, 16)],
+        ["CAM", "0.3", None, (8, 16, 16)],
+        ["ScoreCAM", "0.3", None, (8, 16, 16)],
+        ["SSCAM", "0.3", 4, (8, 16, 16)],
+        ["ISCAM", "0.3", 4, (8, 16, 16)],
     ],
 )
-def test_video_cams(cam_name, target_layer, num_samples, output_size, mock_video_model, mock_video_tensor):
+def test_video_cams(
+    cam_name,
+    target_layer,
+    num_samples,
+    output_size,
+    mock_video_model,
+    mock_video_tensor,
+):
     model = mock_video_model.eval()
     kwargs = {}
     # Speed up testing by reducing the number of samples
     if isinstance(num_samples, int):
-        kwargs['num_samples'] = num_samples
+        kwargs["num_samples"] = num_samples
 
     # Hook the corresponding layer in the model
     extractor = cam.__dict__[cam_name](model, target_layer, **kwargs)


### PR DESCRIPTION
This PR allows the user to pass a `nn.Module` to `target_layer` in each Cam constructor. 

Done:
- [x] `self.target_layer` always hold a reference to the correct `nn.Module`. 
- [x] updated test

Todo:
- [ ] update doc

Current issues:

- [ ] Test for the `__repr__` method fails
- [ ] Minor code duplication in `Cam` `__init__` 