### PR TITLE
refactor: Updated the timing function for latency eval

### DIFF
--- a/scripts/eval_latency.py
+++ b/scripts/eval_latency.py
@@ -48,9 +48,9 @@ def main(args):
         class_idx = scores.squeeze(0).argmax().item() if args.class_idx is None else args.class_idx
 
         # Use the hooked data to compute activation map
-        start_ts = time.time()
+        start_ts = time.perf_counter()
         _ = cam_extractor(class_idx, scores)
-        timings.append(time.time() - start_ts)
+        timings.append(time.perf_counter() - start_ts)
 
     _timings = np.array(timings)
     print(f"{args.method} w/ {args.arch} ({args.it} runs on ({args.size}, {args.size}) inputs)")


### PR DESCRIPTION
This PR simply replaces `time.time()` with `time.perf_counter()` as it is more recommended for precision latency estimation.