### PR TITLE
chore: Fixed jinja2 deps (subdep of sphinx)

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,3 +5,4 @@ sphinx-copybutton>=0.3.1
 docutils<0.18
 recommonmark>=0.7.1
 sphinx-markdown-tables>=0.0.15
+jinja2<3.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,4 +5,4 @@ sphinx-copybutton>=0.3.1
 docutils<0.18
 recommonmark>=0.7.1
 sphinx-markdown-tables>=0.0.15
-jinja2<3.1
+Jinja2<3.1

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,8 @@ extras["docs"] = deps_list(
     "sphinx-copybutton",
     "docutils",
     "recommonmark",
-    "sphinx-markdown-tables"
+    "sphinx-markdown-tables",
+    "Jinja2",
 )
 
 extras["dev"] = (

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ _deps = [
     "docutils<0.18",
     "recommonmark>=0.7.1",
     "sphinx-markdown-tables>=0.0.15",
+    "jinja2<3.1",  # cf. https://github.com/readthedocs/readthedocs.org/issues/9038
 ]
 
 # Borrowed from https://github.com/huggingface/transformers/blob/master/setup.py

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ _deps = [
     "docutils<0.18",
     "recommonmark>=0.7.1",
     "sphinx-markdown-tables>=0.0.15",
-    "jinja2<3.1",  # cf. https://github.com/readthedocs/readthedocs.org/issues/9038
+    "Jinja2<3.1",  # cf. https://github.com/readthedocs/readthedocs.org/issues/9038
 ]
 
 # Borrowed from https://github.com/huggingface/transformers/blob/master/setup.py


### PR DESCRIPTION
This PR fixes sphinx sub-dependencies by pinning jinja2 (cf. https://github.com/readthedocs/readthedocs.org/issues/9038)