### PR TITLE
fix: Fixed division by zero during normalization

### DIFF
--- a/torchcam/methods/activation.py
+++ b/torchcam/methods/activation.py
@@ -204,7 +204,7 @@ class ScoreCAM(_CAM):
 
         # Normalize the activation
         # (N, C, H', W')
-        upsampled_a = [self._normalize(act, act.ndim - 2) for act in self.hook_a]
+        upsampled_a = [self._normalize(act.clone(), act.ndim - 2) for act in self.hook_a]
 
         # Upsample it to input_size
         # (N, C, H, W)

--- a/torchcam/methods/core.py
+++ b/torchcam/methods/core.py
@@ -108,11 +108,12 @@ class _CAM:
 
     @staticmethod
     @torch.no_grad()
-    def _normalize(cams: Tensor, spatial_dims: Optional[int] = None) -> Tensor:
+    def _normalize(cams: Tensor, spatial_dims: Optional[int] = None, eps: float = 1e-8) -> Tensor:
         """CAM normalization."""
         spatial_dims = cams.ndim - 1 if spatial_dims is None else spatial_dims
         cams.sub_(cams.flatten(start_dim=-spatial_dims).min(-1).values[(...,) + (None,) * spatial_dims])
-        cams.div_(cams.flatten(start_dim=-spatial_dims).max(-1).values[(...,) + (None,) * spatial_dims])
+        # Avoid division by zero
+        cams.div_(cams.flatten(start_dim=-spatial_dims).max(-1).values[(...,) + (None,) * spatial_dims] + eps)
 
         return cams
 


### PR DESCRIPTION
This PR introduces the following modifications:
- avoids inplace modifications of activation hook values
- avoids division by zero during normalization by adding an eps to the denominator
- adds a specific unittest to validate non-zero division

Closes #156