### PR TITLE
fix: Fixed zero division for weight computation in gradient based methods

### DIFF
--- a/tests/test_methods_activation.py
+++ b/tests/test_methods_activation.py
@@ -20,7 +20,7 @@ def _verify_cam(activation_map, output_size):
     # Simple verifications
     assert isinstance(activation_map, torch.Tensor)
     assert activation_map.shape == output_size
-    assert not torch.any(torch.isnan(activation_map))
+    assert not torch.isnan(activation_map).any()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_methods_gradient.py
+++ b/tests/test_methods_gradient.py
@@ -10,7 +10,7 @@ def _verify_cam(activation_map, output_size):
     # Simple verifications
     assert isinstance(activation_map, torch.Tensor)
     assert activation_map.shape == output_size
-    assert not torch.any(torch.isnan(activation_map))
+    assert not torch.isnan(activation_map).any()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR introduces an `eps` to all divisions in gradient methods to avoid NaNs.

Closes #186