### PR TITLE
feat: Removes model hooks when the context manager exits

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,16 +77,16 @@ from torchvision.models import resnet18
 from torchcam.methods import SmoothGradCAMpp
 
 model = resnet18(pretrained=True).eval()
-cam_extractor = SmoothGradCAMpp(model)
 # Get your input
 img = read_image("path/to/your/image.png")
 # Preprocess it for your chosen model
 input_tensor = normalize(resize(img, (224, 224)) / 255., [0.485, 0.456, 0.406], [0.229, 0.224, 0.225])
 
-# Preprocess your data and feed it to the model
-out = model(input_tensor.unsqueeze(0))
-# Retrieve the CAM by passing the class index and the model output
-activation_map = cam_extractor(out.squeeze(0).argmax().item(), out)
+with SmoothGradCAMpp(model) as cam_extractor:
+  # Preprocess your data and feed it to the model
+  out = model(input_tensor.unsqueeze(0))
+  # Retrieve the CAM by passing the class index and the model output
+  activation_map = cam_extractor(out.squeeze(0).argmax().item(), out)
 ```
 
 If you want to visualize your heatmap, you only need to cast the CAM to a numpy ndarray:

--- a/scripts/eval_perf.py
+++ b/scripts/eval_perf.py
@@ -60,14 +60,14 @@ def main(args):
     )
 
     # Hook the corresponding layer in the model
-    cam_extractor = methods.__dict__[args.method](model, args.target.split(","))
-    metric = ClassificationMetric(cam_extractor, partial(torch.softmax, dim=-1))
+    with methods.__dict__[args.method](model, args.target.split(",")) as cam_extractor:
+        metric = ClassificationMetric(cam_extractor, partial(torch.softmax, dim=-1))
 
-    # Evaluation runs
-    for x, _ in loader:
-        model.zero_grad()
-        x = x.to(device=device)
-        metric.update(x)
+        # Evaluation runs
+        for x, _ in loader:
+            model.zero_grad()
+            x = x.to(device=device)
+            metric.update(x)
 
     print(f"{args.method} w/ {args.arch} (validation set of Imagenette on ({args.size}, {args.size}) inputs)")
     metrics_dict = metric.summary()

--- a/tests/test_methods_core.py
+++ b/tests/test_methods_core.py
@@ -21,6 +21,21 @@ def test_cam_constructor(mock_img_model):
         _ = core._CAM(model, torch.nn.ReLU())
 
 
+def test_cam_destructor(mock_img_model):
+    model = mock_img_model.eval()
+    extractor = core._CAM(model)
+    # Model is hooked
+    assert sum(len(mod._forward_hooks) for mod in model.modules()) == 1
+    # Delete should remove hooks
+    del extractor
+    assert all(len(mod._forward_hooks) == 0 for mod in model.modules())
+
+    core._CAM(model)
+    assert sum(len(mod._forward_hooks) for mod in model.modules()) == 1
+    # Dereference should also remove hooks
+    assert all(len(mod._forward_hooks) == 0 for mod in model.modules())
+
+
 def test_cam_precheck(mock_img_model, mock_img_tensor):
     model = mock_img_model.eval()
     extractor = core._CAM(model, "0.3")

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -10,13 +10,13 @@ from torchcam.methods import LayerCAM
 def test_classification_metric():
 
     model = mobilenet_v3_small(pretrained=False)
-    extractor = LayerCAM(model, "features.12")
-    metric = metrics.ClassificationMetric(extractor, partial(torch.softmax, dim=-1))
+    with LayerCAM(model, "features.12") as extractor:
+        metric = metrics.ClassificationMetric(extractor, partial(torch.softmax, dim=-1))
 
-    # Fixed class
-    metric.update(torch.rand((2, 3, 224, 224), dtype=torch.float32), class_idx=0)
-    # Top predicted class
-    metric.update(torch.rand((2, 3, 224, 224), dtype=torch.float32))
+        # Fixed class
+        metric.update(torch.rand((2, 3, 224, 224), dtype=torch.float32), class_idx=0)
+        # Top predicted class
+        metric.update(torch.rand((2, 3, 224, 224), dtype=torch.float32))
     out = metric.summary()
 
     assert len(out) == 2

--- a/torchcam/methods/core.py
+++ b/torchcam/methods/core.py
@@ -77,6 +77,10 @@ class _CAM:
         # Model output is used by the extractor
         self._score_used = False
 
+    def __del__(self):
+        self.reset_hooks()
+        self.remove_hooks()
+
     def _resolve_layer_name(self, target_layer: nn.Module) -> str:
         """Resolves the name of a given layer inside the hooked model."""
         _found = False

--- a/torchcam/methods/core.py
+++ b/torchcam/methods/core.py
@@ -77,9 +77,12 @@ class _CAM:
         # Model output is used by the extractor
         self._score_used = False
 
-    def __del__(self):
-        self.reset_hooks()
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exct_type, exce_value, traceback):
         self.remove_hooks()
+        self.reset_hooks()
 
     def _resolve_layer_name(self, target_layer: nn.Module) -> str:
         """Resolves the name of a given layer inside the hooked model."""


### PR DESCRIPTION
This PR removes hooks & hook data before exiting the context manager.

Closes #197 