### PR TITLE
fix: Fixes SmoothGradCAMpp

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,17 +23,18 @@ def mock_img_tensor():
     except ConnectionError:
         img_tensor = torch.rand((1, 3, 224, 224))
 
+    img_tensor.requires_grad_(True)
     return img_tensor
 
 
 @pytest.fixture(scope="session")
 def mock_video_tensor():
-    return torch.rand((1, 3, 8, 16, 16))
+    return torch.rand((1, 3, 8, 16, 16), requires_grad=True)
 
 
 @pytest.fixture(scope="session")
 def mock_video_model():
-    return nn.Sequential(
+    model = nn.Sequential(
         nn.Sequential(
             nn.Conv3d(3, 8, 3, padding=1),
             nn.ReLU(),
@@ -44,11 +45,14 @@ def mock_video_model():
         nn.Flatten(1),
         nn.Linear(16, 1),
     )
+    for p in model:
+        p.requires_grad_(False)
+    return model
 
 
 @pytest.fixture(scope="session")
 def mock_img_model():
-    return nn.Sequential(
+    model = nn.Sequential(
         nn.Sequential(
             nn.Conv2d(3, 8, 3, padding=1),
             nn.ReLU(),
@@ -59,11 +63,14 @@ def mock_img_model():
         nn.Flatten(1),
         nn.Linear(16, 1),
     )
+    for p in model:
+        p.requires_grad_(False)
+    return model
 
 
 @pytest.fixture(scope="session")
 def mock_fullyconv_model():
-    return nn.Sequential(
+    model = nn.Sequential(
         nn.Sequential(
             nn.Conv2d(3, 8, 3, padding=1),
             nn.ReLU(),
@@ -74,3 +81,6 @@ def mock_fullyconv_model():
         nn.Conv2d(16, 1, 1),
         nn.Flatten(1),
     )
+    for p in model:
+        p.requires_grad_(False)
+    return model

--- a/tests/test_methods_activation.py
+++ b/tests/test_methods_activation.py
@@ -7,6 +7,8 @@ from torchcam.methods import activation
 
 def test_base_cam_constructor(mock_img_model):
     model = mobilenet_v2(pretrained=False).eval()
+    for p in model.parameters():
+        p.requires_grad_(False)
     # Check that multiple target layers is disabled for base CAM
     with pytest.raises(ValueError):
         activation.CAM(model, ["classifier.1", "classifier.2"])
@@ -38,6 +40,8 @@ def _verify_cam(activation_map, output_size):
 )
 def test_img_cams(cam_name, target_layer, fc_layer, num_samples, output_size, batch_size, mock_img_tensor):
     model = mobilenet_v2(pretrained=False).eval()
+    for p in model.parameters():
+        p.requires_grad_(False)
     kwargs = {}
     # Speed up testing by reducing the number of samples
     if isinstance(num_samples, int):

--- a/tests/test_methods_utils.py
+++ b/tests/test_methods_utils.py
@@ -6,10 +6,14 @@ from torchcam.methods import _utils
 def test_locate_candidate_layer(mock_img_model):
     # ResNet-18
     mod = resnet18().eval()
+    for p in mod.parameters():
+        p.requires_grad_(False)
     assert _utils.locate_candidate_layer(mod) == "layer4"
 
     # Mobilenet V3 Large
     mod = mobilenet_v3_large().eval()
+    for p in mod.parameters():
+        p.requires_grad_(False)
     assert _utils.locate_candidate_layer(mod) == "features"
 
     # Custom model
@@ -24,6 +28,8 @@ def test_locate_linear_layer(mock_img_model):
 
     # ResNet-18
     mod = resnet18().eval()
+    for p in mod.parameters():
+        p.requires_grad_(False)
     assert _utils.locate_linear_layer(mod) == "fc"
 
     # Custom model

--- a/torchcam/methods/core.py
+++ b/torchcam/methods/core.py
@@ -100,7 +100,7 @@ class _CAM:
 
         return target_name
 
-    def _hook_a(self, module: nn.Module, input: Tensor, output: Tensor, idx: int = 0) -> None:
+    def _hook_a(self, module: nn.Module, input: Tuple[Tensor, ...], output: Tensor, idx: int = 0) -> None:
         """Activation hook."""
         if self._hooks_enabled:
             self.hook_a[idx] = output.data

--- a/torchcam/methods/gradient.py
+++ b/torchcam/methods/gradient.py
@@ -275,6 +275,7 @@ class SmoothGradCAMpp(_GradCAM):
         for _idx in range(self.num_samples):
             # Add noise
             noisy_input = self._input + self._distrib.sample(self._input.size()).to(device=self._input.device)
+            noisy_input.requires_grad_(True)
             # Forward & Backward
             out = self.model(noisy_input)
             self.model.zero_grad()

--- a/torchcam/methods/gradient.py
+++ b/torchcam/methods/gradient.py
@@ -44,7 +44,7 @@ class _GradCAM(_CAM):
         if self._hooks_enabled:
             self.hook_g[idx] = grad.data
 
-    def _hook_g(self, module: nn.Module, input: Tensor, output: Tensor, idx: int = 0) -> None:
+    def _hook_g(self, module: nn.Module, input: Tuple[Tensor, ...], output: Tensor, idx: int = 0) -> None:
         """Gradient hook"""
         if self._hooks_enabled:
             self.hook_handles.append(output.register_hook(partial(self._store_grad, idx=idx)))


### PR DESCRIPTION
This PR introduces the following modifications:
- updates the test suites to be in a more complex setting where models' parameters don't require gradients but input tensors do
- fixes SmoothGradCAMpp that wasn't requiring grad computation from the noisy input


Closes #202