### PR TITLE
refactor: Replaces flake8 by ruff and updates python version

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -18,7 +18,7 @@ build:
 
 requirements:
   host:
-    - python>=3.6, <4.0
+    - python>=3.8, <4.0
     - setuptools
 
   run:

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,0 @@
-[flake8]
-max-line-length = 120
-ignore = E203, E402, E265, F403, W503, W504, E731
-exclude = .github, .git, venv*, docs, build
-per-file-ignores = **/__init__.py:F401

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -13,11 +13,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: [3.7, 3.8]
+        python: [3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -13,11 +13,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: [3.7, 3.8]
+        python: [3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64

--- a/.github/workflows/doc-status.yml
+++ b/.github/workflows/doc-status.yml
@@ -6,10 +6,10 @@ jobs:
   see-page-build-payload:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v1
+      - name: Set up Python
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
           architecture: x64
       - name: check status
         run: |

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Set up python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
       - name: Install requests
         run: pip install requests
       - name: Process commit and find merger responsible for labeling

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
           architecture: x64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
           architecture: x64
@@ -44,8 +44,8 @@ jobs:
     needs: pypi-publish
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v1
+      - name: Set up Python
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
           architecture: x64

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
@@ -45,7 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -7,7 +7,7 @@ on:
     branches: main
 
 jobs:
-  flake8:
+  ruff:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -20,11 +20,11 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
-      - name: Run flake8
+      - name: Run ruff
         run: |
-          pip install flake8
-          flake8 --version
-          flake8
+          pip install ruff
+          ruff --version
+          ruff check --diff .
 
   isort:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
@@ -83,7 +83,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
@@ -102,13 +102,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
       - name: Run black
         run: |
-          pip install black
+          pip install "black==22.3.0"
           black --version
           black --check --diff .
 
@@ -121,7 +121,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: debug-statements
+        language_version: python3
       - id: check-merge-conflict
       - id: no-commit-to-branch
         args: ['--branch', 'main']
@@ -22,12 +23,8 @@ repos:
     rev: 5.10.1
     hooks:
       - id: isort
-  - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+        exclude: "(__init__.py)$"
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: 'v0.0.260'
     hooks:
-      - id: flake8
-        exclude: docs
-  - repo: https://github.com/PyCQA/autoflake
-    rev: v1.7.7
-    hooks:
-      - id: autoflake
+      - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,4 @@ repos:
     rev: 'v0.0.260'
     hooks:
       - id: ruff
+        exclude: "(__init__.py)$"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # this target runs checks on all files
 quality:
 	isort . -c
-	flake8
+	ruff check .
 	mypy
 	pydocstyle
 	black --check .
@@ -12,7 +12,7 @@ quality:
 style:
 	isort .
 	black .
-	autoflake --in-place -r .
+	ruff --fix .
 
 # Run tests for the library
 test:

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ quality:
 	pydocstyle
 	black --check .
 	bandit -r . -c pyproject.toml
-	autoflake -r .
 
 # this target runs checks on all files and potentially modifies some of them
 style:

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ plt.imshow(result); plt.axis('off'); plt.tight_layout(); plt.show()
 
 ## Setup
 
-Python 3.6 (or higher) and [pip](https://pip.pypa.io/en/stable/)/[conda](https://docs.conda.io/en/latest/miniconda.html) are required to install TorchCAM.
+Python 3.8 (or higher) and [pip](https://pip.pypa.io/en/stable/)/[conda](https://docs.conda.io/en/latest/miniconda.html) are required to install TorchCAM.
 
 ### Stable release
 

--- a/docs/source/installing.rst
+++ b/docs/source/installing.rst
@@ -3,7 +3,7 @@
 Installation
 ************
 
-This library requires `Python <https://www.python.org/downloads/>`_ 3.6 or higher.
+This library requires `Python <https://www.python.org/downloads/>`_ 3.8 or higher.
 
 Via Python Package
 ==================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,18 @@ exclude = ["demo*", "docs*", "notebooks*", "scripts*", "tests*"]
 [tool.coverage.run]
 source = ["torchcam"]
 
+[tool.ruff]
+ignore = ["E402", "F403", "E731"]
+exclude = [".git", "venv*", "build", "docs"]
+line-length = 120
+target-version = "py38"
+
+[tool.ruff.per-file-ignores]
+"**/__init__.py" = ["F401"]
+
+[tool.ruff.flake8-quotes]
+docstring-quotes = "double"
+
 [tool.mypy]
 files = "torchcam/"
 show_error_codes = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
     {name = "François-Guillaume Fernandez", email = "fg-feedback@protonmail.com"}
 ]
 readme = "README.md"
-requires-python = ">=3.6,<4"
+requires-python = ">=3.8,<4"
 license = {file = "LICENSE"}
 keywords = ["pytorch", "deep learning", "class activation map", "cnn", "gradcam"]
 classifiers = [
@@ -20,10 +20,9 @@ classifiers = [
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Mathematics",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
@@ -46,12 +45,11 @@ test = [
     "torchvision>=0.4.0,<1.0.0",
 ]
 quality = [
-    "flake8>=3.9.0",
+    "ruff>=0.0.260,<1.0.0",
     "isort>=5.7.0",
-    "mypy>=0.812",
+    "mypy>=1.2.0",
     "pydocstyle[toml]>=6.0.0",
-    "black>=22.1,<23.0",
-    "autoflake>=1.5.0,<2.0.0",
+    "black==22.3.0",
     "bandit[toml]>=1.7.0,<1.8.0",
     "pre-commit>=2.17.0,<3.0.0",
 ]
@@ -77,11 +75,13 @@ dev = [
     "requests>=2.20.0,<3.0.0",
     "torchvision>=0.4.0,<1.0.0",
     # style
-    "flake8>=3.9.0",
+    "ruff>=0.0.260,<1.0.0",
     "isort>=5.7.0",
-    "mypy>=0.812",
+    "mypy>=1.2.0",
     "pydocstyle[toml]>=6.0.0",
-    "black>=22.1,<23.0",
+    "black==22.3.0",
+    "bandit[toml]>=1.7.0,<1.8.0",
+    "pre-commit>=2.17.0,<3.0.0",
     # docs
     "sphinx>=3.0.0,!=3.5.0",
     "furo>=2022.3.4",
@@ -104,6 +104,8 @@ zip-safe = true
 [tool.setuptools.packages.find]
 exclude = ["demo*", "docs*", "notebooks*", "scripts*", "tests*"]
 
+[tool.coverage.run]
+source = ["torchcam"]
 
 [tool.mypy]
 files = "torchcam/"
@@ -134,17 +136,9 @@ known_third_party = ["torch", "torchvision"]
 select = "D300,D301,D417"
 match = ".*\\.py"
 
-[tool.coverage.run]
-source = ["torchcam"]
-
 [tool.black]
 line-length = 120
 target-version = ['py38']
-
-[tool.autoflake]
-remove-unused-variables = true
-remove-all-unused-imports = true
-ignore-init-module-imports = true
 
 [tool.bandit]
 exclude_dirs = [".github/collect_env.py"]


### PR DESCRIPTION
This PR introduces the following modifications:
- drops support for python 3.6 and 3.7
- replaces flake8 and autoflake by ruff
- updates the CI, makefile, documentation