### PR TITLE
ci: Fix precommit hook test for the branch guard

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -81,9 +81,10 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
-      - name: Run ruff
+      - name: Run pre-commit hooks
         run: |
           pip install pre-commit
+          git checkout -b temp
           pre-commit install
           pre-commit --version
           pre-commit run --all-files


### PR DESCRIPTION
This PR fixes the test of precommit that doesn't work on main because of the branch guard.