### PR TITLE
build(deps-dev): bump ruff to 0.3.0 and replace pip with uv

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -15,42 +15,30 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python: [3.8, 3.9, '3.10', 3.11]
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
-      - name: Cache python modules
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-python-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}-build
       - name: Install package
         run: |
-          python -m pip install --upgrade pip
-          pip install -e . --upgrade
+          python -m pip install --upgrade uv
+          uv pip install --system --upgrade -e "torchcam @ ."
       - name: Import package
         run: python -c "import torchcam; print(torchcam.__version__)"
 
   pypi:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.9
           architecture: x64
-      - name: Cache python modules
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-python-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}-build
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel twine --upgrade
+          python -m pip install --upgrade uv
+          uv pip install --system --upgrade setuptools wheel twine
       - run: |
           python setup.py sdist bdist_wheel
           twine check dist/*
@@ -58,7 +46,7 @@ jobs:
   conda:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install package
         run: |
           python -m pip install --upgrade uv
-          uv pip install --system --upgrade -e "torchcam @ ."
+          uv pip install --system --upgrade -e .
       - name: Import package
         run: python -c "import torchcam; print(torchcam.__version__)"
 

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -15,21 +15,15 @@ jobs:
         os: [ubuntu-latest]
         python: [3.9]
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
-      - name: Cache python modules
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-python-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}-demo
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[demo]" --upgrade
+          python -m pip install --upgrade uv
+          uv pip install --system --upgrade -e "torchcam[demo] @ ."
 
       - name: Run demo app
         run: |

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade uv
-          uv pip install --system --upgrade -e "torchcam[demo] @ ."
+          uv pip install --system --upgrade -e ".[demo]"
 
       - name: Run demo app
         run: |

--- a/.github/workflows/doc-status.yml
+++ b/.github/workflows/doc-status.yml
@@ -6,7 +6,7 @@ jobs:
   see-page-build-payload:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.9
           architecture: x64

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade uv
-          uv pip install --system -e "torchcam[docs] @ ."
+          uv pip install --system -e ".[docs]"
 
       - name: Build documentation
         run: cd docs && bash build.sh

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -11,23 +11,17 @@ jobs:
         os: [ubuntu-latest]
         python: [3.9]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - name: Set up Python
-        uses: actions/setup-python@v1
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
-      - name: Cache python modules
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-python-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}-docs
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[docs]"
+          python -m pip install --upgrade uv
+          uv pip install --system -e "torchcam[docs] @ ."
 
       - name: Build documentation
         run: cd docs && bash build.sh

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,20 +9,15 @@ jobs:
     if: "!github.event.release.prerelease"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.9
           architecture: x64
-      - name: Cache python modules
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-python-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}-build
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel twine --upgrade
+          python -m pip install --upgrade uv
+          uv pip install --system --upgrade setuptools wheel twine
       - name: Build and publish
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
@@ -38,23 +33,22 @@ jobs:
     runs-on: ubuntu-latest
     needs: pypi
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.9
           architecture: x64
       - name: Install package
         run: |
-          python -m pip install --upgrade pip
-          pip install torchcam
+          python -m pip install --upgrade uv
+          uv pip install --system torchcam
           python -c "import torchcam; print(torchcam.__version__)"
 
   conda:
     if: "!github.event.release.prerelease"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Miniconda setup
         uses: conda-incubator/setup-miniconda@v3
         with:
@@ -80,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: conda
     steps:
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
           python-version: 3.9

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade uv
-          uv pip install --system -e "torchcam[docs] @ ."
+          uv pip install --system -e ".[docs]"
 
       - name: Build documentation
         run: cd docs && bash build.sh

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade uv
-          uv pip install -e "torchcam[docs] @ ."
+          uv pip install --system -e "torchcam[docs] @ ."
 
       - name: Build documentation
         run: cd docs && bash build.sh

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -8,21 +8,15 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.9
           architecture: x64
-      - name: Cache python modules
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-python-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}-docs
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[docs]"
+          python -m pip install --upgrade uv
+          uv pip install -e "torchcam[docs] @ ."
 
       - name: Build documentation
         run: cd docs && bash build.sh

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -15,22 +15,16 @@ jobs:
         os: [ubuntu-latest]
         python: [3.9]
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
-      - name: Cache python modules
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-python-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}-scripts
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -e . --upgrade
-          pip install -r scripts/requirements.txt
+          python -m pip install --upgrade uv
+          uv pip install --system --upgrade -e "torchcam @ ."
+          uv pip install --system -r scripts/requirements.txt
 
       - name: Run analysis script
         run: python scripts/cam_example.py --arch resnet18 --class-idx 232 --noblock --method LayerCAM
@@ -43,22 +37,16 @@ jobs:
         os: [ubuntu-latest]
         python: [3.9]
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
-      - name: Cache python modules
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-python-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}-scripts
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -e . --upgrade
-          pip install -r scripts/requirements.txt
+          python -m pip install --upgrade uv
+          uv pip install --system --upgrade -e "torchcam @ ."
+          uv pip install --system -r scripts/requirements.txt
 
       - name: Run analysis script
         run: python scripts/eval_latency.py --arch resnet18 LayerCAM

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade uv
-          uv pip install --system --upgrade -e "torchcam @ ."
+          uv pip install --system --upgrade -e .
           uv pip install --system -r scripts/requirements.txt
 
       - name: Run analysis script

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade uv
-          uv pip install --system --upgrade -e "torchcam @ ."
+          uv pip install --system --upgrade -e .
           uv pip install --system -r scripts/requirements.txt
 
       - name: Run analysis script

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -21,7 +21,7 @@ jobs:
           architecture: x64
       - name: Run ruff
         run: |
-          pip install ruff==0.2.0
+          pip install ruff==0.3.0
           ruff --version
           ruff check --diff .
 
@@ -65,7 +65,7 @@ jobs:
           architecture: x64
       - name: Run ruff
         run: |
-          pip install ruff==0.2.0
+          pip install ruff==0.3.0
           ruff --version
           ruff format --check --diff .
 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -14,14 +14,15 @@ jobs:
         os: [ubuntu-latest]
         python: [3.9]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
       - name: Run ruff
         run: |
-          pip install ruff==0.3.0
+          python -m pip install --upgrade uv
+          uv pip install --system ruff==0.3.0
           ruff --version
           ruff check --diff .
 
@@ -32,20 +33,15 @@ jobs:
         os: [ubuntu-latest]
         python: [3.9]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
-      - name: Cache python modules
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-python-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[quality]" --upgrade
+          python -m pip install --upgrade uv
+          uv pip install --system --upgrade -e "torchcam[quality] @ ."
       - name: Run mypy
         run: |
           mypy --version
@@ -58,14 +54,15 @@ jobs:
         os: [ubuntu-latest]
         python: [3.9]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
       - name: Run ruff
         run: |
-          pip install ruff==0.3.0
+          python -m pip install --upgrade uv
+          uv pip install --system ruff==0.3.0
           ruff --version
           ruff format --check --diff .
 
@@ -76,14 +73,15 @@ jobs:
         os: [ubuntu-latest]
         python: [3.9]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
       - name: Run pre-commit hooks
         run: |
-          pip install pre-commit
+          python -m pip install --upgrade uv
+          uv pip install --system pre-commit
           git checkout -b temp
           pre-commit install
           pre-commit --version

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade uv
-          uv pip install --system --upgrade -e "torchcam[quality] @ ."
+          uv pip install --system --upgrade -e ".[quality]"
       - name: Run mypy
         run: |
           mypy --version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,23 +14,17 @@ jobs:
         os: [ubuntu-latest]
         python: [3.9]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
-      - name: Cache python modules
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-python-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}-test
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[test]"
+          python -m pip install --upgrade uv
+          uv pip install --system -e "torchcam[test] @ ."
       - name: Run unittests
         run: pytest --cov=torchcam --cov-report xml tests/
       - uses: actions/upload-artifact@v2
@@ -42,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: pytest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
       - uses: actions/download-artifact@v2
@@ -59,7 +53,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Check the headers

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade uv
-          uv pip install --system -e "torchcam[test] @ ."
+          uv pip install --system -e ".[test]"
       - name: Run unittests
         run: pytest --cov=torchcam --cov-report xml tests/
       - uses: actions/upload-artifact@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 'v0.2.0'
+    rev: 'v0.3.0'
     hooks:
       - id: ruff
         args:

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ quality:
 # this target runs checks on all files and potentially modifies some of them
 style:
 	ruff format .
-	ruff --fix .
+	ruff check --fix .
 
 # Run tests for the library
 test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ test = [
     "pytest-pretty>=1.0.0,<2.0.0",
 ]
 quality = [
-    "ruff==0.2.0",
+    "ruff==0.3.0",
     "mypy==1.8.0",
     "pre-commit>=3.0.0,<4.0.0",
 ]
@@ -76,7 +76,7 @@ dev = [
     "pytest-cov>=4.0.0,<5.0.0",
     "pytest-pretty>=1.0.0,<2.0.0",
     # style
-    "ruff==0.2.0",
+    "ruff==0.3.0",
     "mypy==1.8.0",
     "pre-commit>=3.0.0,<4.0.0",
     # docs


### PR DESCRIPTION
This PR introduces the following modifications:
- bumps ruff to 0.3.0
- replace pip with uv in the CI