### PR TITLE
ci(dependabot): add dependabot update for a few packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      time: "06:00"
+      timezone: "Europe/Paris"
+    groups:
+      gh-actions:
+        patterns:
+          - "*"
+    reviewers:
+      - "frgfm"
+    assignees:
+      - "frgfm"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "06:00"
+      timezone: "Europe/Paris"
+    reviewers:
+      - "frgfm"
+    assignees:
+      - "frgfm"
+    allow:
+      - dependency-name: "ruff"
+      - dependency-name: "mypy"
+      - dependency-name: "pre-commit"


### PR DESCRIPTION
This PR adds the config for dependabot updates that aren't related to security.