### PR TITLE
ci(github): bump uv to 0.5.13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.11"
-  UV_VERSION: "0.5.7"
+  UV_VERSION: "0.5.13"
 
 jobs:
   package:

--- a/.github/workflows/page-build.yml
+++ b/.github/workflows/page-build.yml
@@ -4,7 +4,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.11"
-  UV_VERSION: "0.5.7"
+  UV_VERSION: "0.5.13"
 
 jobs:
   check-gh-pages:

--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.11"
-  UV_VERSION: "0.5.7"
+  UV_VERSION: "0.5.13"
 
 jobs:
   is-properly-labeled:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -5,7 +5,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.11"
-  UV_VERSION: "0.5.7"
+  UV_VERSION: "0.5.13"
 
 jobs:
   docs-deploy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.11"
-  UV_VERSION: "0.5.7"
+  UV_VERSION: "0.5.13"
 
 jobs:
   pypi:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.11"
-  UV_VERSION: "0.5.7"
+  UV_VERSION: "0.5.13"
 
 jobs:
   ruff:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.11"
-  UV_VERSION: "0.5.7"
+  UV_VERSION: "0.5.13"
 
 
 jobs:


### PR DESCRIPTION
This PR bumps uv to the latest version for the CI.