### PR TITLE
fix(methods): restore hook and model state on errors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,7 +26,7 @@ updates:
       - "dependencies"
       - "type: misc"
     commit-message:
-      prefix: "build(deps-dev)"
+      prefix: "build(deps)"
     schedule:
       interval: "daily"
       time: "08:00"
@@ -35,29 +35,16 @@ updates:
       - dependency-name: "ruff"
       - dependency-name: "ty"
       - dependency-name: "prek"
+      - dependency-name: "pytest"
+      - dependency-name: "pytest-cov"
+      - dependency-name: "pytest-pretty"
     groups:
       quality:
         patterns:
           - "ruff"
           - "ty"
           - "prek"
-  - package-ecosystem: "pip"
-    directory: "/"
-    labels:
-      - "dependencies"
-      - "type: misc"
-    commit-message:
-      prefix: "build(deps-test)"
-    schedule:
-      interval: "daily"
-      time: "08:00"
-    allow:
-      # Safe updates
-      - dependency-name: "pytest"
-      - dependency-name: "pytest-cov"
-      - dependency-name: "pytest-pretty"
-    groups:
-      quality:
+      tests:
         patterns:
           - "pytest"
           - "pytest-cov"

--- a/demo/app.py
+++ b/demo/app.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021-2025, François-Guillaume Fernandez.
+# Copyright (C) 2021-2026, François-Guillaume Fernandez.
 
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.

--- a/scripts/cam_example.py
+++ b/scripts/cam_example.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2025, François-Guillaume Fernandez.
+# Copyright (C) 2020-2026, François-Guillaume Fernandez.
 
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.

--- a/scripts/eval_latency.py
+++ b/scripts/eval_latency.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021-2025, François-Guillaume Fernandez.
+# Copyright (C) 2021-2026, François-Guillaume Fernandez.
 
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.

--- a/scripts/eval_perf.py
+++ b/scripts/eval_perf.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2025, François-Guillaume Fernandez.
+# Copyright (C) 2022-2026, François-Guillaume Fernandez.
 
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.

--- a/tests/test_methods_activation.py
+++ b/tests/test_methods_activation.py
@@ -82,6 +82,27 @@ def test_cam_conv1x1(mock_fullyconv_model):
         _verify_cam(extractor(scores[0].argmax().item(), scores)[0], (1, 32, 32))
 
 
+def test_scorecam_restores_state_on_error(mock_img_tensor, monkeypatch):
+    model = get_model("mobilenet_v2", weights=None).train()
+    for p in model.parameters():
+        p.requires_grad_(False)
+
+    with activation.ScoreCAM(model, "features.16.conv.3", batch_size=8) as extractor:
+        extractor.enable_hooks()
+        scores = model(mock_img_tensor)
+        monkeypatch.setattr(
+            extractor,
+            "_get_score_weights",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+
+        with pytest.raises(RuntimeError):
+            extractor(scores[0].argmax().item(), scores)
+
+        assert extractor._hooks_enabled
+        assert model.training
+
+
 @pytest.mark.parametrize(
     ("cam_name", "target_layer", "num_samples", "output_size"),
     [

--- a/tests/test_methods_core.py
+++ b/tests/test_methods_core.py
@@ -30,6 +30,47 @@ def test_cam_context_manager(mock_img_model):
     assert all(len(mod._forward_hooks) == 0 for mod in model.modules())
 
 
+def test_cam_context_manager_cleans_up_on_exception(mock_img_model):
+    model = mock_img_model.eval()
+    with pytest.raises(RuntimeError), core._CAM(model, "0.3") as extractor:
+        raise RuntimeError("boom")
+    assert len(extractor.hook_handles) == 0
+    assert all(len(mod._forward_hooks) == 0 for mod in model.modules())
+
+
+def test_cam_hooks_off_restores_state(mock_img_model):
+    model = mock_img_model.eval()
+    with core._CAM(model, "0.3", enable_hooks=False) as extractor:
+        assert not extractor._hooks_enabled
+        with extractor._hooks_off():
+            assert not extractor._hooks_enabled
+        assert not extractor._hooks_enabled
+
+        extractor.enable_hooks()
+        with extractor._hooks_off():
+            assert not extractor._hooks_enabled
+        assert extractor._hooks_enabled
+
+
+def test_cam_eval_mode_restores_state(mock_img_model):
+    model = mock_img_model.train()
+    model[0][1].eval()
+    with core._CAM(model, "0.3") as extractor:
+        with extractor._eval_mode():
+            assert all(not module.training for module in extractor.model.modules())
+        assert extractor.model.training
+        assert model[0][0].training
+        assert not model[0][1].training
+
+
+def test_cam_remove_hooks_idempotent(mock_img_model):
+    model = mock_img_model.eval()
+    with core._CAM(model, "0.3") as extractor:
+        extractor.remove_hooks()
+        extractor.remove_hooks()
+        assert len(extractor.hook_handles) == 0
+
+
 def test_cam_precheck(mock_img_model, mock_img_tensor):
     model = mock_img_model.eval()
     with core._CAM(model, "0.3") as extractor, torch.no_grad():

--- a/tests/test_methods_core.py
+++ b/tests/test_methods_core.py
@@ -52,7 +52,7 @@ def test_cam_hooks_off_restores_state(mock_img_model):
         assert extractor._hooks_enabled
 
 
-def test_cam_eval_mode_restores_state(mock_img_model):
+def test_cam_eval_mode_restores_state(mock_img_model, monkeypatch):
     model = mock_img_model.train()
     model[0][1].eval()
     with core._CAM(model, "0.3") as extractor:
@@ -61,6 +61,18 @@ def test_cam_eval_mode_restores_state(mock_img_model):
         assert extractor.model.training
         assert model[0][0].training
         assert not model[0][1].training
+
+        modes = [module.training for module in model.modules()]
+
+        def failing_eval():
+            for module in model.modules():
+                module.training = False
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(model, "eval", failing_eval)
+        with pytest.raises(RuntimeError), extractor._eval_mode():
+            pass
+        assert [module.training for module in model.modules()] == modes
 
 
 def test_cam_remove_hooks_idempotent(mock_img_model):

--- a/tests/test_methods_gradient.py
+++ b/tests/test_methods_gradient.py
@@ -112,3 +112,36 @@ def test_layercam_fuse_cams():
     assert isinstance(cam, torch.Tensor)
     assert cam.ndim == cams[0].ndim
     assert cam.shape == (1, 16, 16)
+
+
+def test_gradcam_does_not_accumulate_hook_handles(mock_img_tensor):
+    model = get_model("mobilenet_v2", weights=None).eval()
+    for p in model.parameters():
+        p.requires_grad_(False)
+
+    with gradient.GradCAM(model, "features.18.0") as extractor:
+        initial_handles = len(extractor.hook_handles)
+        for _ in range(3):
+            scores = model(mock_img_tensor)
+            extractor(scores[0].argmax().item(), scores, retain_graph=True)
+        assert len(extractor.hook_handles) == initial_handles
+
+
+def test_smoothgradcampp_restores_input_hook_on_error(mock_img_tensor, monkeypatch):
+    model = get_model("mobilenet_v2", weights=None).eval()
+    for p in model.parameters():
+        p.requires_grad_(False)
+
+    with gradient.SmoothGradCAMpp(model, "features.18.0", num_samples=1) as extractor:
+        scores = model(mock_img_tensor)
+        extractor._ihook_enabled = False
+        monkeypatch.setattr(
+            extractor,
+            "_backprop",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+
+        with pytest.raises(RuntimeError):
+            extractor(scores[0].argmax().item(), scores)
+
+        assert not extractor._ihook_enabled

--- a/tests/test_methods_gradient.py
+++ b/tests/test_methods_gradient.py
@@ -125,6 +125,7 @@ def test_gradcam_does_not_accumulate_hook_handles(mock_img_tensor):
             scores = model(mock_img_tensor)
             extractor(scores[0].argmax().item(), scores, retain_graph=True)
         assert len(extractor.hook_handles) == initial_handles
+        assert len(extractor._grad_hook_handles) == len(extractor.target_names)
 
 
 def test_smoothgradcampp_restores_input_hook_on_error(mock_img_tensor, monkeypatch):
@@ -134,7 +135,6 @@ def test_smoothgradcampp_restores_input_hook_on_error(mock_img_tensor, monkeypat
 
     with gradient.SmoothGradCAMpp(model, "features.18.0", num_samples=1) as extractor:
         scores = model(mock_img_tensor)
-        extractor._ihook_enabled = False
         monkeypatch.setattr(
             extractor,
             "_backprop",
@@ -144,4 +144,4 @@ def test_smoothgradcampp_restores_input_hook_on_error(mock_img_tensor, monkeypat
         with pytest.raises(RuntimeError):
             extractor(scores[0].argmax().item(), scores)
 
-        assert not extractor._ihook_enabled
+        assert extractor._ihook_enabled

--- a/tests/test_methods_utils.py
+++ b/tests/test_methods_utils.py
@@ -1,9 +1,10 @@
+import pytest
 from torchvision.models import get_model
 
 from torchcam.methods import _utils
 
 
-def test_locate_candidate_layer(mock_img_model):
+def test_locate_candidate_layer(mock_img_model, monkeypatch):
     # ResNet-18
     mod = get_model("resnet18", weights=None).eval()
     for p in mod.parameters():
@@ -25,3 +26,15 @@ def test_locate_candidate_layer(mock_img_model):
     assert mod.training
     assert mod[0][0].training
     assert not mod[0][1].training
+
+    modes = [module.training for module in mod.modules()]
+
+    def failing_eval():
+        for module in mod.modules():
+            module.training = False
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(mod, "eval", failing_eval)
+    with pytest.raises(RuntimeError):
+        _utils.locate_candidate_layer(mod)
+    assert [module.training for module in mod.modules()] == modes

--- a/tests/test_methods_utils.py
+++ b/tests/test_methods_utils.py
@@ -18,7 +18,10 @@ def test_locate_candidate_layer(mock_img_model):
 
     # Custom model
     mod = mock_img_model.train()
+    mod[0][1].eval()
 
     assert _utils.locate_candidate_layer(mod) == "0.3"
     # Check that the model is switched back to its origin mode afterwards
     assert mod.training
+    assert mod[0][0].training
+    assert not mod[0][1].training

--- a/torchcam/methods/_utils.py
+++ b/torchcam/methods/_utils.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2025, François-Guillaume Fernandez.
+# Copyright (C) 2020-2026, François-Guillaume Fernandez.
 
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.

--- a/torchcam/methods/_utils.py
+++ b/torchcam/methods/_utils.py
@@ -22,7 +22,7 @@ def locate_candidate_layer(mod: nn.Module, input_shape: tuple[int, ...] = (3, 22
         the candidate layer for CAM
     """
     # Set module in eval mode
-    module_mode = mod.training
+    module_modes = [(module, module.training) for module in mod.modules()]
     mod.eval()
 
     output_shapes: list[tuple[str | None, tuple[int, ...]]] = []
@@ -32,20 +32,19 @@ def locate_candidate_layer(mod: nn.Module, input_shape: tuple[int, ...] = (3, 22
         output_shapes.append((name, output.shape))
 
     hook_handles: list[torch.utils.hooks.RemovableHandle] = []
-    # forward hook on all layers
-    for n, m in mod.named_modules():
-        hook_handles.append(m.register_forward_hook(partial(_record_output_shape, name=n)))
+    try:
+        # forward hook on all layers
+        for n, m in mod.named_modules():
+            hook_handles.append(m.register_forward_hook(partial(_record_output_shape, name=n)))
 
-    # forward empty
-    with torch.no_grad():
-        _ = mod(torch.zeros((1, *input_shape), device=next(mod.parameters()).data.device))
-
-    # Remove all temporary hooks
-    for handle in hook_handles:
-        handle.remove()
-
-    # Put back the model in the corresponding mode
-    mod.training = module_mode
+        # forward empty
+        with torch.no_grad():
+            _ = mod(torch.zeros((1, *input_shape), device=next(mod.parameters()).device))
+    finally:
+        for handle in hook_handles:
+            handle.remove()
+        for module, training in module_modes:
+            module.training = training
 
     # Check output shapes
     candidate_layer = None

--- a/torchcam/methods/_utils.py
+++ b/torchcam/methods/_utils.py
@@ -23,7 +23,6 @@ def locate_candidate_layer(mod: nn.Module, input_shape: tuple[int, ...] = (3, 22
     """
     # Set module in eval mode
     module_modes = [(module, module.training) for module in mod.modules()]
-    mod.eval()
 
     output_shapes: list[tuple[str | None, tuple[int, ...]]] = []
 
@@ -33,6 +32,7 @@ def locate_candidate_layer(mod: nn.Module, input_shape: tuple[int, ...] = (3, 22
 
     hook_handles: list[torch.utils.hooks.RemovableHandle] = []
     try:
+        mod.eval()
         # forward hook on all layers
         for n, m in mod.named_modules():
             hook_handles.append(m.register_forward_hook(partial(_record_output_shape, name=n)))

--- a/torchcam/methods/activation.py
+++ b/torchcam/methods/activation.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2025, François-Guillaume Fernandez.
+# Copyright (C) 2020-2026, François-Guillaume Fernandez.
 
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.

--- a/torchcam/methods/activation.py
+++ b/torchcam/methods/activation.py
@@ -168,7 +168,7 @@ class ScoreCAM(_CAM):
     def _store_input(self, _: nn.Module, input_: tuple[Any, ...]) -> None:
         """Store model input tensor."""
         if self._hooks_enabled:
-            self._input = input_[0].data.clone()
+            self._input = input_[0].detach().clone()
 
     @torch.no_grad()
     def _get_score_weights(self, activations: list[Tensor], class_idx: int | list[int]) -> list[Tensor]:
@@ -229,20 +229,8 @@ class ScoreCAM(_CAM):
             for up_a in upsampled_a
         ]
 
-        # Disable hook updates
-        self.disable_hooks()
-        # Switch to eval
-        origin_mode = self.model.training
-        self.model.eval()
-
-        weights: list[Tensor] = self._get_score_weights(upsampled_a, class_idx)
-
-        # Reenable hook updates
-        self.enable_hooks()
-        # Put back the model in the correct mode
-        self.model.training = origin_mode
-
-        return weights
+        with self._hooks_off(), self._eval_mode():
+            return self._get_score_weights(upsampled_a, class_idx)
 
     def __repr__(self) -> str:  # noqa: D105
         return f"{self.__class__.__name__}(batch_size={self.bs})"

--- a/torchcam/methods/core.py
+++ b/torchcam/methods/core.py
@@ -5,6 +5,8 @@
 
 import logging
 from abc import abstractmethod
+from collections.abc import Iterator
+from contextlib import contextmanager
 from functools import partial
 from types import TracebackType
 from typing import Any, Self, cast
@@ -92,6 +94,25 @@ class _CAM:
         """Disable hooks."""
         self._hooks_enabled = False
 
+    @contextmanager
+    def _hooks_off(self) -> Iterator[None]:
+        previous = self._hooks_enabled
+        self._hooks_enabled = False
+        try:
+            yield
+        finally:
+            self._hooks_enabled = previous
+
+    @contextmanager
+    def _eval_mode(self) -> Iterator[None]:
+        modes = [(module, module.training) for module in self.model.modules()]
+        self.model.eval()
+        try:
+            yield
+        finally:
+            for module, training in modes:
+                module.training = training
+
     def __enter__(self) -> Self:
         return self
 
@@ -101,8 +122,10 @@ class _CAM:
         exce_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
-        self.remove_hooks()
-        self.reset_hooks()
+        try:
+            self.remove_hooks()
+        finally:
+            self.reset_hooks()
 
     def _resolve_layer_name(self, target_layer: nn.Module) -> str:
         """Resolves the name of a given layer inside the hooked model."""  # noqa: DOC201, DOC501
@@ -114,7 +137,7 @@ class _CAM:
     def _hook_a(self, _: nn.Module, _input: tuple[Tensor, ...], output: Tensor, idx: int = 0) -> None:
         """Activation hook."""
         if self._hooks_enabled:
-            self.hook_a[idx] = output.data
+            self.hook_a[idx] = output.detach()
 
     def reset_hooks(self) -> None:
         """Clear stored activation and gradients."""

--- a/torchcam/methods/core.py
+++ b/torchcam/methods/core.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2025, François-Guillaume Fernandez.
+# Copyright (C) 2020-2026, François-Guillaume Fernandez.
 
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.

--- a/torchcam/methods/core.py
+++ b/torchcam/methods/core.py
@@ -106,8 +106,8 @@ class _CAM:
     @contextmanager
     def _eval_mode(self) -> Iterator[None]:
         modes = [(module, module.training) for module in self.model.modules()]
-        self.model.eval()
         try:
+            self.model.eval()
             yield
         finally:
             for module, training in modes:

--- a/torchcam/methods/gradient.py
+++ b/torchcam/methods/gradient.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2025, François-Guillaume Fernandez.
+# Copyright (C) 2020-2026, François-Guillaume Fernandez.
 
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.

--- a/torchcam/methods/gradient.py
+++ b/torchcam/methods/gradient.py
@@ -38,15 +38,26 @@ class _GradCAM(_CAM):
         for idx, name in enumerate(self.target_names):
             # Trick to avoid issues with inplace operations cf. https://github.com/pytorch/pytorch/issues/61519
             self.hook_handles.append(self.submodule_dict[name].register_forward_hook(partial(self._hook_g, idx=idx)))
+        self._grad_hook_handles: list[torch.utils.hooks.RemovableHandle | None] = [None] * len(self.target_names)
 
     def _store_grad(self, grad: Tensor, idx: int = 0) -> None:
         if self._hooks_enabled:
-            self.hook_g[idx] = grad.data
+            self.hook_g[idx] = grad.detach()
 
     def _hook_g(self, _: nn.Module, _input: tuple[Tensor, ...], output: Tensor, idx: int = 0) -> None:
         """Gradient hook."""
         if self._hooks_enabled:
-            self.hook_handles.append(output.register_hook(partial(self._store_grad, idx=idx)))
+            handle = self._grad_hook_handles[idx]
+            if handle is not None:
+                handle.remove()
+            self._grad_hook_handles[idx] = output.register_hook(partial(self._store_grad, idx=idx))
+
+    def remove_hooks(self) -> None:
+        for handle in self._grad_hook_handles:
+            if handle is not None:
+                handle.remove()
+        self._grad_hook_handles = [None] * len(self.target_names)
+        super().remove_hooks()
 
     def _backprop(
         self,
@@ -271,7 +282,7 @@ class SmoothGradCAMpp(_GradCAM):
     def _store_input(self, _: nn.Module, input_: tuple[Any, ...]) -> None:
         """Store model input tensor."""
         if self._ihook_enabled:
-            self._input = input_[0].data.clone()
+            self._input = input_[0].detach().clone()
 
     def _get_weights(
         self,
@@ -281,8 +292,19 @@ class SmoothGradCAMpp(_GradCAM):
         **kwargs: Any,
     ) -> list[Tensor]:
         """Computes the weight coefficients of the hooked activation maps."""  # noqa: DOC201
-        # Disable input update
+        previous_ihook_enabled = self._ihook_enabled
         self._ihook_enabled = False
+        try:
+            return self._compute_smoothgrad_weights(class_idx, eps, **kwargs)
+        finally:
+            self._ihook_enabled = previous_ihook_enabled
+
+    def _compute_smoothgrad_weights(
+        self,
+        class_idx: int | list[int],
+        eps: float,
+        **kwargs: Any,
+    ) -> list[Tensor]:
         # Keep initial activation
         self.hook_a: list[Tensor]  # type: ignore[assignment]
         self.hook_g: list[Tensor]  # type: ignore[assignment]
@@ -303,9 +325,6 @@ class SmoothGradCAMpp(_GradCAM):
             # Sum partial derivatives
             grad_2 = [g2.add_(grad.pow(2)) for g2, grad in zip(grad_2, self.hook_g, strict=True)]
             grad_3 = [g3.add_(grad.pow(3)) for g3, grad in zip(grad_3, self.hook_g, strict=True)]
-
-        # Reenable input update
-        self._ihook_enabled = True
 
         # Average the gradient estimates
         grad_2 = [g2.div_(self.num_samples) for g2 in grad_2]

--- a/torchcam/metrics.py
+++ b/torchcam/metrics.py
@@ -94,31 +94,29 @@ class ClassificationMetric:
             cams = self.cam_extractor(preds.cpu().numpy().tolist(), probs)
             cam = self.cam_extractor.fuse_cams(cams)
             probs = probs.gather(1, preds.unsqueeze(1)).squeeze(1)
-        self.cam_extractor.disable_hooks()
-        # Safeguard: skip NaNs
-        discard = torch.isnan(cam).reshape(input_tensor.shape[0], -1).any(dim=-1)
-        cam = cam[~discard, ...]
-        probs = probs[~discard]
-        if class_idx is None:
-            preds = preds[~discard]
-        input_tensor = input_tensor[~discard]
-        # Resize the CAM
-        cam = torch.nn.functional.interpolate(cam.unsqueeze(1), input_tensor.shape[-2:], mode="bilinear")
-        # Create the explanation map & get the new probs
-        with torch.inference_mode():
-            masked_probs = self._get_probs(cam * input_tensor)
-        masked_probs = (
-            masked_probs[:, class_idx]
-            if isinstance(class_idx, int)
-            else masked_probs.gather(1, preds.unsqueeze(1)).squeeze(1)
-        )
-        # Drop (avoid division by zero)
-        drop = torch.relu(probs - masked_probs).div(probs + 1e-7)
+        with self.cam_extractor._hooks_off():  # noqa: SLF001
+            # Safeguard: skip NaNs
+            discard = torch.isnan(cam).reshape(input_tensor.shape[0], -1).any(dim=-1)
+            cam = cam[~discard, ...]
+            probs = probs[~discard]
+            if class_idx is None:
+                preds = preds[~discard]
+            input_tensor = input_tensor[~discard]
+            # Resize the CAM
+            cam = torch.nn.functional.interpolate(cam.unsqueeze(1), input_tensor.shape[-2:], mode="bilinear")
+            # Create the explanation map & get the new probs
+            with torch.inference_mode():
+                masked_probs = self._get_probs(cam * input_tensor)
+            masked_probs = (
+                masked_probs[:, class_idx]
+                if isinstance(class_idx, int)
+                else masked_probs.gather(1, preds.unsqueeze(1)).squeeze(1)
+            )
+            # Drop (avoid division by zero)
+            drop = torch.relu(probs - masked_probs).div(probs + 1e-7)
 
-        # Increase
-        increase = probs < masked_probs
-
-        self.cam_extractor.enable_hooks()
+            # Increase
+            increase = probs < masked_probs
 
         self.drop += drop.sum().item()
         self.increase += increase.sum().item()

--- a/torchcam/metrics.py
+++ b/torchcam/metrics.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2025, François-Guillaume Fernandez.
+# Copyright (C) 2022-2026, François-Guillaume Fernandez.
 
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.

--- a/torchcam/utils.py
+++ b/torchcam/utils.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2025, François-Guillaume Fernandez.
+# Copyright (C) 2020-2026, François-Guillaume Fernandez.
 
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.


### PR DESCRIPTION
## Summary

- Add `_hooks_off()` and `_eval_mode()` context managers on `_CAM` so hook and training state are restored on success and exceptions.
- Preserve mixed train/eval state for every model submodule instead of restoring only the root flag.
- Stop accumulating gradient backward-hook handles across repeated forwards in `_GradCAM`.
- Store hooked activations, gradients, and inputs with `detach()` instead of `.data`.
- Wrap ScoreCAM, SmoothGradCAMpp, metrics, and layer-probing utilities in exception-safe cleanup paths.
- Repair the pre-existing repository checks exposed by this source PR: consolidate overlapping pip Dependabot entries and refresh validator-scoped headers for 2026.

## Test plan

- [x] `make quality`
- [x] `make test` (49 passed)
- [x] Added regression coverage for mixed submodule train/eval restoration.
- [x] Added tests for exception cleanup, idempotent hook removal, ScoreCAM/SmoothGradCAMpp restoration, and stable gradient-hook counts.
- [x] Validated Dependabot YAML structure and unique ecosystem/directory combinations.

Made with [Cursor](https://cursor.com)