### PR TITLE
chore: update astral deps (uv, ruff, prek, ty)

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -3,15 +3,24 @@ name: demo
 on:
   push:
     branches: main
+    paths:
+      - '.github/workflows/demo.yml'
+      - 'demo/**'
+      - 'pyproject.toml'
   pull_request:
     branches: main
+    paths:
+      - '.github/workflows/demo.yml'
+      - 'demo/**'
+      - 'pyproject.toml'
+  workflow_dispatch:  # Allow manual trigger from Actions tab
 
 env:
   PYTHON_VERSION: "3.11"
-  UV_VERSION: "0.9.5"
+  UV_VERSION: "0.11.24"  # pinned for reproducible installs across all jobs
 
 jobs:
-  demo:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -31,3 +40,17 @@ jobs:
         run: |
           screen -dm streamlit run demo/app.py --server.port 8080
           sleep 10 && nc -vz localhost 8080
+
+  sync-to-hub:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          lfs: true
+      - name: Push to hub
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: git push https://frgfm:$HF_TOKEN@huggingface.co/spaces/frgfm/torch-cam main

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.11"
-  UV_VERSION: "0.9.5"
+  UV_VERSION: "0.11.24"
 
 jobs:
   build:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -21,7 +21,7 @@ on:
     types: [published]
 
 env:
-  UV_VERSION: "0.9.5"
+  UV_VERSION: "0.11.24"
   PYTHON_VERSION: "3.11"
 
 

--- a/.github/workflows/page-build.yml
+++ b/.github/workflows/page-build.yml
@@ -4,7 +4,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.11"
-  UV_VERSION: "0.9.5"
+  UV_VERSION: "0.11.24"
 
 jobs:
   check-gh-pages:

--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.11"
-  UV_VERSION: "0.9.5"
+  UV_VERSION: "0.11.24"
 
 jobs:
   is-properly-labeled:

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.11"
-  UV_VERSION: "0.9.5"
+  UV_VERSION: "0.11.24"
 
 
 jobs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
       - id: conventional-pre-commit
         stages: [commit-msg]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 'v0.14.2'
+    rev: 'v0.15.19'
     hooks:
       - id: ruff
         args: ["--fix", "--config", "./pyproject.toml"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["uv_build>=0.9.5,<0.10.0"]
+requires = ["uv_build>=0.11.24,<0.12.0"]
 build-backend = "uv_build"
 
 [project]
@@ -54,10 +54,10 @@ test = [
     "pytest-pretty==1.3.0",
 ]
 quality = [
-    "ruff==0.14.2",
-    "ty==0.0.1a25",
+    "ruff==0.15.19",
+    "ty==0.0.53",
     "types-Pillow",
-    "prek==0.2.12",
+    "prek==0.4.5",
 ]
 docs = [
     # cf. https://github.com/mkdocs/catalog

--- a/scripts/cam_example.py
+++ b/scripts/cam_example.py
@@ -98,12 +98,12 @@ def main(args):
 
     # Clear axes
     if num_cols > 1:
-        for _axes in axes:
+        for axes_ in axes:
             if args.rows > 1:
-                for ax in _axes:
+                for ax in axes_:
                     ax.axis("off")
             else:
-                _axes.axis("off")
+                axes_.axis("off")
 
     else:
         axes.axis("off")

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -19,4 +19,4 @@ def test_classification_metric():
     out = metric.summary()
 
     assert len(out) == 2
-    assert all(0 <= v <= 1 for k, v in out.items())
+    assert all(0 <= v <= 1 for v in out.values())

--- a/torchcam/methods/_utils.py
+++ b/torchcam/methods/_utils.py
@@ -45,7 +45,7 @@ def locate_candidate_layer(mod: nn.Module, input_shape: tuple[int, ...] = (3, 22
         handle.remove()
 
     # Put back the model in the corresponding mode
-    mod.training = module_mode  # ty: ignore[unresolved-attribute]
+    mod.training = module_mode
 
     # Check output shapes
     candidate_layer = None

--- a/torchcam/methods/activation.py
+++ b/torchcam/methods/activation.py
@@ -194,8 +194,8 @@ class ScoreCAM(_CAM):
 
         for idx, scored_input in enumerate(scored_inputs):
             # Process by chunk (GPU RAM limitation)
-            for _idx in range(math.ceil(weights[idx].numel() / self.bs)):
-                slice_ = slice(_idx * self.bs, min((_idx + 1) * self.bs, weights[idx].numel()))
+            for idx_ in range(math.ceil(weights[idx].numel() / self.bs)):
+                slice_ = slice(idx_ * self.bs, min((idx_ + 1) * self.bs, weights[idx].numel()))
                 # Get the softmax probabilities of the target class
                 # (*, M)
                 cic = self.model(scored_input[slice_]) - logits[idcs[slice_]]
@@ -246,7 +246,7 @@ class ScoreCAM(_CAM):
         # Reenable hook updates
         self.enable_hooks()
         # Put back the model in the correct mode
-        self.model.training = origin_mode  # ty: ignore[invalid-assignment]
+        self.model.training = origin_mode
 
         return weights
 
@@ -318,7 +318,7 @@ class SSCAM(ScoreCAM):
 
         self.num_samples = num_samples
         self.std = std
-        self._distrib = torch.distributions.normal.Normal(0, self.std)  # ty: ignore[unresolved-attribute]
+        self._distrib = torch.distributions.normal.Normal(0, self.std)
 
     @torch.no_grad()
     def _get_score_weights(self, activations: list[Tensor], class_idx: int | list[int]) -> list[Tensor]:
@@ -342,8 +342,8 @@ class SSCAM(ScoreCAM):
                 scored_input = scored_input.view(b * c, *scored_input.shape[2:])
 
                 # Process by chunk (GPU RAM limitation)
-                for _idx in range(math.ceil(weights[idx].numel() / self.bs)):
-                    slice_ = slice(_idx * self.bs, min((_idx + 1) * self.bs, weights[idx].numel()))
+                for idx_ in range(math.ceil(weights[idx].numel() / self.bs)):
+                    slice_ = slice(idx_ * self.bs, min((idx_ + 1) * self.bs, weights[idx].numel()))
                     # Get the softmax probabilities of the target class
                     cic = self.model(scored_input[slice_]) - logits[idcs[slice_]]
                     if isinstance(class_idx, int):
@@ -442,8 +442,8 @@ class ISCAM(ScoreCAM):
                 coeff += (sidx + 1) / self.num_samples
 
                 # Process by chunk (GPU RAM limitation)
-                for _idx in range(math.ceil(weights[idx].numel() / self.bs)):
-                    slice_ = slice(_idx * self.bs, min((_idx + 1) * self.bs, weights[idx].numel()))
+                for idx_ in range(math.ceil(weights[idx].numel() / self.bs)):
+                    slice_ = slice(idx_ * self.bs, min((idx_ + 1) * self.bs, weights[idx].numel()))
                     # Get the softmax probabilities of the target class
                     cic = self.model(coeff * scored_input[slice_]) - logits[idcs[slice_]]
                     if isinstance(class_idx, int):

--- a/torchcam/methods/core.py
+++ b/torchcam/methods/core.py
@@ -8,7 +8,7 @@ import sys
 from abc import abstractmethod
 from functools import partial
 from types import TracebackType
-from typing import Any
+from typing import Any, Self
 
 import torch
 import torch.nn.functional as F
@@ -98,7 +98,7 @@ class _CAM:
         """Disable hooks."""
         self._hooks_enabled = False
 
-    def __enter__(self) -> "_CAM":
+    def __enter__(self) -> Self:
         return self
 
     def __exit__(
@@ -167,7 +167,7 @@ class _CAM:
 
         # Check class_idx value
         if (not isinstance(class_idx, int) or class_idx < 0) and (
-            not isinstance(class_idx, list) or any(_idx < 0 for _idx in class_idx)
+            not isinstance(class_idx, list) or any(idx < 0 for idx in class_idx)
         ):
             raise ValueError("Incorrect `class_idx` argument value")
 

--- a/torchcam/methods/gradient.py
+++ b/torchcam/methods/gradient.py
@@ -264,7 +264,7 @@ class SmoothGradCAMpp(_GradCAM):
         # Noise distribution
         self.num_samples = num_samples
         self.std = std
-        self._distrib = torch.distributions.normal.Normal(0, self.std)  # ty: ignore[unresolved-attribute]
+        self._distrib = torch.distributions.normal.Normal(0, self.std)
         # Specific input hook updater
         self._ihook_enabled = True
 


### PR DESCRIPTION
Updates pinned dependencies to latest versions:

- uv: 0.9.5 → 0.11.24
- ruff: 0.14.2 → 0.15.19
- prek: 0.2.12 → 0.4.5
- ty: 0.0.1a25 → 0.0.53

Updated in: pyproject.toml, .pre-commit-config.yaml, and all GitHub Actions workflow files.