### PR TITLE
build(deps-dev): bump ty from 0.0.53 to 0.0.65

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ test = [
 ]
 quality = [
     "ruff==0.15.19",
-    "ty==0.0.53",
+    "ty==0.0.65",
     "types-Pillow",
     "prek==0.4.5",
 ]


### PR DESCRIPTION
## Summary
- update ty from 0.0.53 to 0.0.65

## Validation
- dependency synchronization check passes
- ty 0.0.65 matches ty 0.0.53 baseline: 4 existing diagnostics in the Python 3.11 project environment