### PR TITLE
build(deps-dev): bump ruff from 0.15.19 to 0.16.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
       - id: conventional-pre-commit
         stages: [commit-msg]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 'v0.15.19'
+    rev: 'v0.16.0'
     hooks:
       - id: ruff
         args: ["--fix", "--config", "./pyproject.toml"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ test = [
     "pytest-pretty==1.3.0",
 ]
 quality = [
-    "ruff==0.15.19",
+    "ruff==0.16.0",
     "ty==0.0.53",
     "types-Pillow",
     "prek==0.4.5",
@@ -174,6 +174,8 @@ ignore = [
     "PLR2004",  # magic value comparison
     "PLR0913",  # too many arguments in function definition
     "PLR0917",  # too many positional arguments in function definition
+    "RUF105",  # preserve noqa comments
+    "RUF201",  # preserve rule codes in selectors
 ]
 exclude = [".git"]
 
@@ -196,6 +198,7 @@ known-third-party = ["torch", "torchvision"]
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"
+exclude = ["*.md"]
 
 [tool.ty.environment]
 python-version = "3.11"


### PR DESCRIPTION
## Summary
- update Ruff and ruff-pre-commit from 0.15.19 to 0.16.0
- preserve the existing noqa, rule-selector, and Markdown formatting conventions by excluding new preview-only behavior

## Validation
- Ruff 0.16.0 lint passes
- Ruff 0.16.0 format check passes
- Ruff pre-commit hooks pass
- dependency synchronization check passes