### PR TITLE
build(deps-dev): bump prek from 0.4.5 to 0.4.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ quality = [
     "ruff==0.15.19",
     "ty==0.0.53",
     "types-Pillow",
-    "prek==0.4.5",
+    "prek==0.4.11",
 ]
 docs = [
     # cf. https://github.com/mkdocs/catalog


### PR DESCRIPTION
## Summary
- update prek from 0.4.5 to 0.4.11

## Validation
- dependency synchronization check passes
- all pre-commit hooks pass except the existing ty check
- prek 0.4.5 and 0.4.11 both report the same 4 existing ty diagnostics