### PR TITLE
build(deps-dev): bump uv from 0.11.24 to 0.12.0

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.11"
-  UV_VERSION: "0.11.24"  # pinned for reproducible installs across all jobs
+  UV_VERSION: "0.12.0"  # pinned for reproducible installs across all jobs
 
 jobs:
   build:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.11"
-  UV_VERSION: "0.11.24"
+  UV_VERSION: "0.12.0"
 
 jobs:
   build:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -21,7 +21,7 @@ on:
     types: [published]
 
 env:
-  UV_VERSION: "0.11.24"
+  UV_VERSION: "0.12.0"
   PYTHON_VERSION: "3.11"
 
 

--- a/.github/workflows/page-build.yml
+++ b/.github/workflows/page-build.yml
@@ -4,7 +4,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.11"
-  UV_VERSION: "0.11.24"
+  UV_VERSION: "0.12.0"
 
 jobs:
   check-gh-pages:

--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.11"
-  UV_VERSION: "0.11.24"
+  UV_VERSION: "0.12.0"
 
 jobs:
   is-properly-labeled:

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.11"
-  UV_VERSION: "0.11.24"
+  UV_VERSION: "0.12.0"
 
 
 jobs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["uv_build>=0.11.24,<0.12.0"]
+requires = ["uv_build>=0.12.0,<0.13.0"]
 build-backend = "uv_build"
 
 [project]


### PR DESCRIPTION
## Summary
- update the uv pin in all GitHub Actions workflows from 0.11.24 to 0.12.0
- update uv_build from the 0.11 release line to 0.12

## Validation
- dependency synchronization check passes
- workflow YAML validation passes
- uv 0.12.0 builds the source distribution and wheel successfully