### PR TITLE
build(deps-dev): update quality tools

### DIFF
--- a/.github/verify_deps_sync.py
+++ b/.github/verify_deps_sync.py
@@ -48,7 +48,6 @@ def main():  # noqa: PLR0912
     # Retrieve & parse all deps files
     deps_dict = {
         "uv": [],
-        "ruff": [],
         "ty": [],
         "pre-commit": [],
     }
@@ -58,8 +57,6 @@ def main():  # noqa: PLR0912
     for repo in precommit["repos"]:
         if repo["repo"] == "https://github.com/astral-sh/uv-pre-commit":
             deps_dict["uv"].append({"file": PRECOMMIT_CONFIG, "version": f"=={repo['rev'].lstrip('v')}"})
-        elif repo["repo"] == "https://github.com/charliermarsh/ruff-pre-commit":
-            deps_dict["ruff"].append({"file": PRECOMMIT_CONFIG, "version": f"=={repo['rev'].lstrip('v')}"})
     # Parse pyproject.toml
     for pyproject_path in PYPROJECTS:
         with Path(pyproject_path).open("rb") as f:

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.11"
-  UV_VERSION: "0.11.24"  # pinned for reproducible installs across all jobs
+  UV_VERSION: "0.12.0"  # pinned for reproducible installs across all jobs
 
 jobs:
   build:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.11"
-  UV_VERSION: "0.11.24"
+  UV_VERSION: "0.12.0"
 
 jobs:
   build:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -21,7 +21,7 @@ on:
     types: [published]
 
 env:
-  UV_VERSION: "0.11.24"
+  UV_VERSION: "0.12.0"
   PYTHON_VERSION: "3.11"
 
 

--- a/.github/workflows/page-build.yml
+++ b/.github/workflows/page-build.yml
@@ -4,7 +4,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.11"
-  UV_VERSION: "0.11.24"
+  UV_VERSION: "0.12.0"
 
 jobs:
   check-gh-pages:

--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.11"
-  UV_VERSION: "0.11.24"
+  UV_VERSION: "0.12.0"
 
 jobs:
   is-properly-labeled:

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.11"
-  UV_VERSION: "0.11.24"
+  UV_VERSION: "0.12.0"
 
 
 jobs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
       - id: conventional-pre-commit
         stages: [commit-msg]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 'v0.15.19'
+    rev: 'v0.16.0'
     hooks:
       - id: ruff
         args: ["--fix", "--config", "./pyproject.toml"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,13 +26,6 @@ repos:
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 'v0.16.0'
-    hooks:
-      - id: ruff
-        args: ["--fix", "--config", "./pyproject.toml"]
-      - id: ruff-format
-        args: ["--config", "./pyproject.toml"]
   - repo: https://github.com/abravalheri/validate-pyproject
     rev: v0.24.1
     hooks:
@@ -40,6 +33,18 @@ repos:
         args: ["./pyproject.toml"]
   - repo: local
     hooks:
+      - id: ruff-lint
+        name: ruff-lint
+        entry: make ruff-lint-fix
+        pass_filenames: false
+        require_serial: true
+        language: system
+      - id: ruff-format
+        name: ruff-format
+        entry: make ruff-format-fix
+        pass_filenames: false
+        require_serial: true
+        language: system
       - id: deps-check
         name: check deps version sync
         entry: make deps-check

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ DOCS_DIR = ./docs
 
 
 
-.PHONY: help install install-quality lint-check lint-format precommit typing-check deps-check quality style init-gh-labels init-gh-settings install-mintlify start-mintlify
+.PHONY: help install install-quality ruff-lint ruff-lint-fix ruff-format ruff-format-fix lint-check lint-format precommit typing-check deps-check quality style init-gh-labels init-gh-settings install-mintlify start-mintlify
 
 help: ## Show this help message
 	@echo "Available commands:"
@@ -31,19 +31,27 @@ install: ${PY_DIR} ${PYPROJECT_FILE} ## Install the core library
 install-quality: ${PY_DIR} ${PYPROJECT_FILE} ## Install with quality dependencies
 	uv pip install -e '${PY_DIR}[quality]'
 
-lint-check: ${PYPROJECT_FILE} ## Check code formatting and linting
-	ruff format --check . --config ${PYPROJECT_FILE}
-	ruff check . --config ${PYPROJECT_FILE}
+ruff-lint: ${PYPROJECT_FILE} ## Check code linting
+	uv run --extra quality ruff check . --config ${PYPROJECT_FILE}
 
-lint-format: ${PYPROJECT_FILE} ## Format code and fix linting issues
-	ruff format . --config ${PYPROJECT_FILE}
-	ruff check --fix . --config ${PYPROJECT_FILE}
+ruff-lint-fix: ${PYPROJECT_FILE} ## Fix code linting
+	uv run --extra quality ruff check --fix . --config ${PYPROJECT_FILE}
+
+ruff-format: ${PYPROJECT_FILE} ## Check code formatting
+	uv run --extra quality ruff format --check . --config ${PYPROJECT_FILE}
+
+ruff-format-fix: ${PYPROJECT_FILE} ## Fix code formatting
+	uv run --extra quality ruff format . --config ${PYPROJECT_FILE}
+
+lint-check: ruff-lint ruff-format ## Check code formatting and linting
+
+lint-format: ruff-lint-fix ruff-format-fix ## Format code and fix linting issues
 
 precommit: ${PYPROJECT_FILE} .pre-commit-config.yaml ## Run pre-commit hooks
-	prek run --all-files
+	uv run --extra quality prek run --all-files
 
 typing-check: ${PYPROJECT_FILE} ## Check type annotations
-	uvx ty check .
+	uv run --extra quality ty check .
 
 deps-check: .github/verify_deps_sync.py ## Check dependency synchronization
 	uv run --script .github/verify_deps_sync.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["uv_build>=0.11.24,<0.12.0"]
+requires = ["uv_build>=0.12.0,<0.13.0"]
 build-backend = "uv_build"
 
 [project]
@@ -54,10 +54,10 @@ test = [
     "pytest-pretty==1.3.0",
 ]
 quality = [
-    "ruff==0.15.19",
-    "ty==0.0.53",
+    "ruff==0.16.0",
+    "ty==0.0.65",
     "types-Pillow",
-    "prek==0.4.5",
+    "prek==0.4.11",
 ]
 docs = [
     # cf. https://github.com/mkdocs/catalog
@@ -174,6 +174,8 @@ ignore = [
     "PLR2004",  # magic value comparison
     "PLR0913",  # too many arguments in function definition
     "PLR0917",  # too many positional arguments in function definition
+    "RUF105",  # preserve noqa comments
+    "RUF201",  # preserve rule codes in selectors
 ]
 exclude = [".git"]
 
@@ -196,6 +198,7 @@ known-third-party = ["torch", "torchvision"]
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"
+exclude = ["*.md"]
 
 [tool.ty.environment]
 python-version = "3.11"

--- a/torchcam/methods/activation.py
+++ b/torchcam/methods/activation.py
@@ -160,12 +160,12 @@ class ScoreCAM(_CAM):
         super().__init__(model, target_layer, input_shape, **kwargs)
 
         # Input hook
-        self.hook_handles.append(model.register_forward_pre_hook(self._store_input))  # type: ignore[arg-type]
+        self.hook_handles.append(model.register_forward_pre_hook(self._store_input))
         self.bs = batch_size
         # Ensure ReLU is applied to CAM before normalization
         self._relu = True
 
-    def _store_input(self, _: nn.Module, input_: Tensor) -> None:
+    def _store_input(self, _: nn.Module, input_: tuple[Any, ...]) -> None:
         """Store model input tensor."""
         if self._hooks_enabled:
             self._input = input_[0].data.clone()

--- a/torchcam/methods/core.py
+++ b/torchcam/methods/core.py
@@ -7,7 +7,7 @@ import logging
 from abc import abstractmethod
 from functools import partial
 from types import TracebackType
-from typing import Any, Self
+from typing import Any, Self, cast
 
 import torch
 import torch.nn.functional as F
@@ -200,10 +200,11 @@ class _CAM:
         weights = self._get_weights(class_idx, scores, **kwargs)
 
         cams: list[Tensor] = []
+        activations = cast(list[Tensor], self.hook_a)
 
         with torch.no_grad():
-            for weight, activation in zip(weights, self.hook_a, strict=True):
-                missing_dims = activation.ndim - weight.ndim  # type: ignore[union-attr]
+            for weight, activation in zip(weights, activations, strict=True):
+                missing_dims = activation.ndim - weight.ndim
                 weight = weight[(...,) + (None,) * missing_dims]  # noqa: PLW2901
 
                 # Perform the weighted combination to get the CAM

--- a/torchcam/methods/gradient.py
+++ b/torchcam/methods/gradient.py
@@ -260,7 +260,7 @@ class SmoothGradCAMpp(_GradCAM):
         self._score_used = False
 
         # Input hook
-        self.hook_handles.append(model.register_forward_pre_hook(self._store_input))  # type: ignore[arg-type]
+        self.hook_handles.append(model.register_forward_pre_hook(self._store_input))
         # Noise distribution
         self.num_samples = num_samples
         self.std = std
@@ -268,7 +268,7 @@ class SmoothGradCAMpp(_GradCAM):
         # Specific input hook updater
         self._ihook_enabled = True
 
-    def _store_input(self, _: nn.Module, input_: Tensor) -> None:
+    def _store_input(self, _: nn.Module, input_: tuple[Any, ...]) -> None:
         """Store model input tensor."""
         if self._ihook_enabled:
             self._input = input_[0].data.clone()


### PR DESCRIPTION
## Summary
- update ty from 0.0.53 to 0.0.65
- update Ruff from 0.15.19 to 0.16.0
- update prek from 0.4.5 to 0.4.11
- update uv and uv_build from the 0.11 release line to 0.12.0
- run Ruff as local system hooks through Make targets, leaving its version pinned only in pyproject.toml
- preserve existing noqa, rule-selector, and Markdown formatting conventions under Ruff 0.16

## Validation
- Makefile Ruff check and fix targets pass
- local Ruff prek hooks pass
- dependency synchronization passes
- uv 0.12.0 builds the source distribution and wheel
- ty 0.0.65 reproduces the same 4 existing diagnostics as ty 0.0.53