### PR TITLE
feat(methods): support ViT reshape transforms

### DIFF
--- a/docs/docs/getting-started/advanced-usage.md
+++ b/docs/docs/getting-started/advanced-usage.md
@@ -151,7 +151,7 @@ dimensions:
 ```python
 from PIL import Image
 from torchvision.models import ViT_B_16_Weights, vit_b_16
-from torchcam.methods import LayerCAM
+from torchcam.methods import GradCAM
 
 weights = ViT_B_16_Weights.DEFAULT
 model = vit_b_16(weights=weights).eval()
@@ -163,12 +163,28 @@ def reshape_transform(tensor):
     return patches.permute(0, 3, 1, 2)
 
 input_tensor = weights.transforms()(image).unsqueeze(0)
-target_layer = model.encoder.layers[-1].ln_1
+target_layer = model.encoder.layers[-2].ln_1
 
-with LayerCAM(model, target_layer, reshape_transform=reshape_transform) as extractor:
+with GradCAM(model, target_layer, reshape_transform=reshape_transform) as extractor:
     scores = model(input_tensor)
     cam = extractor(scores[0].argmax().item(), scores)[0]
 ```
+
+DeiT-Tiny follows the same pattern: target `model.blocks[-1].norm1`, drop `model.num_prefix_tokens`, and reshape
+the remaining tokens using `model.patch_embed.grid_size`.
+
+For a complete example without additional dependencies, run the official pretrained torchvision Swin-T
+(patch size 4, window size 7, input size 224) from the repository checkout:
+
+```bash
+uv run --extra scripts python scripts/cam_example.py \
+    --arch swin_t --method GradCAM \
+    --savefig swin_t_cam.png --noblock
+```
+
+The first run downloads the torchvision Swin-T weights. The script selects the model prediction and targets the
+final block's `norm2`. This layer retains a 7×7 channels-last spatial grid, so its transform only moves the channel
+axis before the spatial axes.
 
 The exact transform is architecture-specific: models may use a different patch grid or have additional prefix
 tokens such as a distillation token. Always specify `target_layer` when using `reshape_transform`. For a ViT,

--- a/docs/docs/getting-started/advanced-usage.md
+++ b/docs/docs/getting-started/advanced-usage.md
@@ -140,36 +140,46 @@ print([n for n, _ in wrapped.named_modules() if n.endswith("layer4")])
 
 ## Vision Transformers and other non-CNN models
 
-TorchCAM's methods operate on **convolutional feature maps** of shape `(N, C, H, W)` (or `(N, C, D, H, W)` in
-3D). Transformer blocks emit token sequences of shape `(N, num_tokens, dim)`, which have no spatial grid, so the
-CAM methods do not apply directly and automatic `target_layer` resolution will not find a suitable layer.
+TorchCAM's methods operate on **spatial feature maps** of shape `(N, C, H, W)` (or `(N, C, D, H, W)` in 3D).
+Transformer blocks emit token sequences of shape `(N, num_tokens, dim)`, which have no spatial grid, so CAM methods
+do not apply directly and automatic `target_layer` resolution cannot infer the token layout.
 
-To use a ViT you have to reshape a block's token output back to a spatial grid (dropping the class token) and
-expose *that* as the `target_layer`. There is no built-in helper yet, but the wrapper below is a starting point —
-it turns a block's `(N, num_tokens, dim)` output into an `(N, dim, H, W)` map:
+Use `reshape_transform` to convert the hooked tokens and their gradients back to a spatial grid. For a torchvision
+ViT, drop the class token, reshape the remaining patch tokens, and move the embedding dimension before the spatial
+dimensions:
 
 ```python
-import torch.nn as nn
+from PIL import Image
+from torchvision.models import ViT_B_16_Weights, vit_b_16
+from torchcam.methods import LayerCAM
 
-class ViTToGrid(nn.Module):
-    """Experimental: reshape a ViT block's token output to a spatial grid for CAM."""
-    def __init__(self, vit_block, h, w):   # h, w = patch grid, e.g. 14x14 for 224px / patch 16
-        super().__init__()
-        self.block = vit_block
-        self.h, self.w = h, w
+weights = ViT_B_16_Weights.DEFAULT
+model = vit_b_16(weights=weights).eval()
+grid_size = model.image_size // model.patch_size
+image = Image.open("path/to/image.jpg").convert("RGB")
 
-    def forward(self, x):
-        out = self.block(x)                                  # (N, num_tokens, dim)
-        return out[:, 1:].transpose(1, 2).reshape(x.size(0), -1, self.h, self.w)  # (N, dim, h, w)
+def reshape_transform(tensor):
+    patches = tensor[:, 1:, :].reshape(tensor.size(0), grid_size, grid_size, tensor.size(-1))
+    return patches.permute(0, 3, 1, 2)
+
+input_tensor = weights.transforms()(image).unsqueeze(0)
+target_layer = model.encoder.layers[-1].ln_1
+
+with LayerCAM(model, target_layer, reshape_transform=reshape_transform) as extractor:
+    scores = model(input_tensor)
+    cam = extractor(scores[0].argmax().item(), scores)[0]
 ```
 
-Insert it into the model in place of the block you want to read, then point the extractor at it.
+The exact transform is architecture-specific: models may use a different patch grid or have additional prefix
+tokens such as a distillation token. Always specify `target_layer` when using `reshape_transform`. For a ViT,
+choose a layer before the final attention operation; patch-token gradients are zero at the complete final block
+output because classification uses only the class token. The selected module must return a tensor, and the same
+transform is applied to every selected target layer. Keep the transform structural—token selection, reshaping, and
+axis permutation—because TorchCAM applies it identically to activation and gradient tensors.
 
-!!! warning "Experimental"
-    This is a sketch, not a drop-in. The exact reshape is architecture-specific (patch grid size, and whether
-    there is a class and/or distillation token to drop), and for gradient-based methods you must read a block
-    whose tokens the class score actually depends on. If you get this working for a model, please share it in the
-    [discussions](https://github.com/frgfm/torch-cam/discussions).
+This enables activation- and gradient-based extractors such as `LayerCAM`, `GradCAM`, and `ScoreCAM`. The original
+weight-based `CAM` method still requires its global-pooling and classifier-weight assumptions, which standard ViTs
+do not satisfy. Attention rollout or attention flow are separate transformer-specific explanation techniques.
 
 ## 3D and video models
 

--- a/scripts/cam_example.py
+++ b/scripts/cam_example.py
@@ -9,6 +9,7 @@ CAM visualization
 
 import argparse
 import math
+from functools import partial
 from io import BytesIO
 
 import matplotlib.pyplot as plt
@@ -16,13 +17,36 @@ import requests
 import torch
 from PIL import Image
 from torchvision.models import get_model, get_model_weights
+from torchvision.models.swin_transformer import SwinTransformer
+from torchvision.models.vision_transformer import VisionTransformer
 from torchvision.transforms.functional import to_pil_image, to_tensor
 
 from torchcam import methods
 from torchcam.utils import overlay_mask
 
 
-def main(args):
+def vit_reshape_transform(tensor, grid_size):
+    patches = tensor[:, 1:, :].reshape(tensor.size(0), grid_size, grid_size, tensor.size(-1))
+    return patches.permute(0, 3, 1, 2)
+
+
+def swin_reshape_transform(tensor):
+    return tensor.permute(0, 3, 1, 2)
+
+
+def resolve_transformer_config(model, target_layer):
+    reshape_transform = None
+    if isinstance(model, VisionTransformer):
+        grid_size = model.image_size // model.patch_size
+        target_layer = target_layer or model.encoder.layers[-2].ln_1
+        reshape_transform = partial(vit_reshape_transform, grid_size=grid_size)
+    elif isinstance(model, SwinTransformer):
+        target_layer = target_layer or model.features[-1][-1].norm2
+        reshape_transform = swin_reshape_transform
+    return target_layer, reshape_transform
+
+
+def main(args):  # noqa: PLR0912
     if args.device is None:
         args.device = "cuda:0" if torch.cuda.is_available() else "cpu"
 
@@ -30,7 +54,7 @@ def main(args):
 
     # Pretrained imagenet model
     weights = get_model_weights(args.arch).DEFAULT
-    model = get_model(args.arch, weights=weights).to(device=device)
+    model = get_model(args.arch, weights=weights).to(device=device).eval()
     # Freeze the model
     for p in model.parameters():
         p.requires_grad_(False)
@@ -44,8 +68,12 @@ def main(args):
     img_tensor = preprocess(to_tensor(pil_img)).to(device=device)
     img_tensor.requires_grad_(True)
 
+    target_layer, reshape_transform = resolve_transformer_config(model, args.target)
+
     if isinstance(args.method, str):
         cam_methods = args.method.split(",")
+    elif reshape_transform is not None:
+        cam_methods = ["GradCAM"]
     else:
         cam_methods = [
             "CAM",
@@ -60,7 +88,13 @@ def main(args):
         ]
     # Hook the corresponding layer in the model
     cam_extractors = [
-        methods.__dict__[name](model, target_layer=args.target, enable_hooks=False) for name in cam_methods
+        methods.__dict__[name](
+            model,
+            target_layer=target_layer,
+            enable_hooks=False,
+            reshape_transform=reshape_transform,
+        )
+        for name in cam_methods
     ]
 
     # Homogenize number of elements in each row
@@ -78,6 +112,8 @@ def main(args):
 
         # Select the class index
         class_idx = scores.squeeze(0).argmax().item() if args.class_idx is None else args.class_idx
+        class_name = weights.meta["categories"][class_idx]
+        print(f"{extractor.__class__.__name__}: class {class_idx} ({class_name})")
 
         # Use the hooked data to compute activation map
         activation_map = extractor(class_idx, scores)[0].squeeze(0).cpu()
@@ -94,7 +130,7 @@ def main(args):
         ax = axes[idx // num_cols][idx % num_cols] if args.rows > 1 else axes[idx] if num_cols > 1 else axes
 
         ax.imshow(result)
-        ax.set_title(extractor.__class__.__name__, size=8)
+        ax.set_title(f"{extractor.__class__.__name__}: {class_name}", size=8)
 
     # Clear axes
     if num_cols > 1:
@@ -111,7 +147,8 @@ def main(args):
     plt.tight_layout()
     if args.savefig:
         plt.savefig(args.savefig, dpi=200, transparent=True, bbox_inches="tight", pad_inches=0)
-    plt.show(block=not args.noblock)
+    if not args.noblock:
+        plt.show()
 
 
 if __name__ == "__main__":
@@ -126,7 +163,7 @@ if __name__ == "__main__":
         default="https://www.woopets.fr/assets/races/000/066/big-portrait/border-collie.jpg",
         help="The image to extract CAM from",
     )
-    parser.add_argument("--class-idx", type=int, default=232, help="Index of the class to inspect")
+    parser.add_argument("--class-idx", type=int, default=None, help="Class index to inspect (defaults to prediction)")
     parser.add_argument(
         "--device",
         type=str,

--- a/tests/test_methods_transformer.py
+++ b/tests/test_methods_transformer.py
@@ -1,0 +1,72 @@
+import pytest
+import torch
+from torchvision.models.vision_transformer import VisionTransformer
+
+from torchcam.methods import LayerCAM, ScoreCAM
+
+
+def _build_vit() -> VisionTransformer:
+    torch.manual_seed(0)
+    model = VisionTransformer(
+        image_size=32,
+        patch_size=8,
+        num_layers=2,
+        num_heads=2,
+        hidden_dim=32,
+        mlp_dim=64,
+        num_classes=10,
+    )
+    torch.nn.init.normal_(model.heads.head.weight)
+    return model.eval()
+
+
+def _reshape_transform(tensor: torch.Tensor) -> torch.Tensor:
+    return tensor[:, 1:].reshape(tensor.shape[0], 4, 4, tensor.shape[-1]).permute(0, 3, 1, 2)
+
+
+def test_reshape_transform_validation():
+    model = _build_vit()
+    target_layer = "encoder.layers.encoder_layer_1.ln_1"
+
+    with pytest.raises(TypeError, match="reshape_transform"):
+        LayerCAM(model, target_layer, reshape_transform=1)
+    with pytest.raises(ValueError, match="target_layer"):
+        LayerCAM(model, reshape_transform=_reshape_transform)
+
+
+def test_layercam_with_reshape_transform():
+    model = _build_vit()
+    input_tensor = torch.randn(1, 3, 32, 32)
+
+    with LayerCAM(
+        model,
+        "encoder.layers.encoder_layer_1.ln_1",
+        reshape_transform=_reshape_transform,
+    ) as extractor:
+        scores = model(input_tensor)
+        cam = extractor(scores[0].argmax().item(), scores)[0]
+
+        assert extractor.hook_a[0].shape == (1, 32, 4, 4)
+        assert extractor.hook_g[0].shape == (1, 32, 4, 4)
+        assert cam.shape == (1, 4, 4)
+        assert torch.isfinite(cam).all()
+        assert cam.std() > 0
+
+
+def test_scorecam_with_reshape_transform():
+    model = _build_vit()
+    input_tensor = torch.randn(1, 3, 32, 32)
+
+    with ScoreCAM(
+        model,
+        "encoder.layers.encoder_layer_1.ln_1",
+        batch_size=16,
+        reshape_transform=_reshape_transform,
+    ) as extractor:
+        scores = model(input_tensor)
+        cam = extractor(scores[0].argmax().item())[0]
+
+        assert extractor.hook_a[0].shape == (1, 32, 4, 4)
+        assert cam.shape == (1, 4, 4)
+        assert torch.isfinite(cam).all()
+        assert cam.std() > 0

--- a/torchcam/methods/core.py
+++ b/torchcam/methods/core.py
@@ -5,7 +5,7 @@
 
 import logging
 from abc import abstractmethod
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from functools import partial
 from types import TracebackType
@@ -30,6 +30,7 @@ class _CAM:
         target_layer: either the target layer itself or its name
         input_shape: shape of the expected input tensor excluding the batch dimension
         enable_hooks: should hooks be enabled by default
+        reshape_transform: optional transform applied to hooked activations and gradients
 
     Raises:
         ValueError: if the argument is invalid
@@ -42,7 +43,13 @@ class _CAM:
         target_layer: nn.Module | str | list[nn.Module | str] | None = None,
         input_shape: tuple[int, ...] = (3, 224, 224),
         enable_hooks: bool = True,
+        reshape_transform: Callable[[Tensor], Tensor] | None = None,
     ) -> None:
+        if reshape_transform is not None and not callable(reshape_transform):
+            raise TypeError("`reshape_transform` must be callable")
+        if reshape_transform is not None and target_layer is None:
+            raise ValueError("`target_layer` must be specified when using `reshape_transform`")
+
         # Obtain a mapping from module name to module instance for each layer in the model
         self.submodule_dict = dict(model.named_modules())
 
@@ -73,6 +80,7 @@ class _CAM:
             raise ValueError(f"Unable to find all submodules {target_names} in the model")
         self.target_names = target_names
         self.model = model
+        self._reshape_transform = reshape_transform
         # Init hooks
         self.reset_hooks()
         self.hook_handles: list[torch.utils.hooks.RemovableHandle] = []
@@ -137,6 +145,8 @@ class _CAM:
     def _hook_a(self, _: nn.Module, _input: tuple[Tensor, ...], output: Tensor, idx: int = 0) -> None:
         """Activation hook."""
         if self._hooks_enabled:
+            if self._reshape_transform is not None:
+                output = self._reshape_transform(output)
             self.hook_a[idx] = output.detach()
 
     def reset_hooks(self) -> None:

--- a/torchcam/methods/gradient.py
+++ b/torchcam/methods/gradient.py
@@ -42,6 +42,8 @@ class _GradCAM(_CAM):
 
     def _store_grad(self, grad: Tensor, idx: int = 0) -> None:
         if self._hooks_enabled:
+            if self._reshape_transform is not None:
+                grad = self._reshape_transform(grad)
             self.hook_g[idx] = grad.detach()
 
     def _hook_g(self, _: nn.Module, _input: tuple[Tensor, ...], output: Tensor, idx: int = 0) -> None:


### PR DESCRIPTION
## Summary

- add an optional `reshape_transform` callback shared by activation and gradient hooks
- require an explicit target layer when transforming non-spatial outputs
- document ViT/DeiT token reshaping and a runnable pretrained Swin-T example
- cover LayerCAM and ScoreCAM with a deterministic tiny Vision Transformer

## Pretrained transformer validation

Run the selected example from the repository checkout:

```bash
uv run --extra scripts python scripts/cam_example.py \
    --arch swin_t --method GradCAM \
    --savefig swin_t_cam.png --noblock
```

The official torchvision Swin-T predicts ImageNet class 232 (`Border collie`). Targeting the final block's `norm1`
produced background-heavy maps, while `norm2` produced a localized 7×7 CAM over the dog's head and neck. The script
therefore uses `model.features[-1][-1].norm2` and moves its channels-last output to `(N, C, H, W)`.

For comparison, pretrained `timm` DeiT-Tiny (`deit_tiny_patch16_224.fb_in1k`) also predicted `Border collie`.
Its final `norm1` produced finite, non-uniform 14×14 maps focused on the dog; this uses the same class-token removal
and patch-grid reshape documented for ViTs. `timm` was used only for this local validation and is not a dependency.

Generated visualizations are not committed to Git. `--savefig` writes the result locally for inspection.

## Test plan

- [x] pretrained Swin-T example predicts `Border collie` and produces a localized GradCAM
- [x] pretrained DeiT-Tiny comparison returns finite, non-uniform 14×14 CAMs
- [x] existing ResNet example invocation
- [x] `make quality`
- [x] `make test` (52 passed)
- [x] `mkdocs build --strict`

Closes #133
