### PR TITLE
Add RefineCAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ This project is developed and maintained by the repo owner, but the implementati
 - [IS-CAM](https://arxiv.org/abs/2010.03023): integration-based variant of Score-CAM.
 - [XGrad-CAM](https://arxiv.org/abs/2008.02312): improved version of Grad-CAM in terms of sensitivity and conservation.
 - [Layer-CAM](http://mftp.mmcheng.net/Papers/21TIP_LayerCAM.pdf): Grad-CAM alternative leveraging pixel-wise contribution of the gradient to the activation.
+- [RefineCAM](https://arxiv.org/abs/2605.14641): multi-layer refinement producing high-resolution activation maps.
 
 *Not sure which one to use? See [Choosing a CAM method](https://frgfm.github.io/torch-cam/getting-started/advanced-usage/#choosing-a-cam-method).*
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -167,6 +167,7 @@ pip install "torchcam @ git+https://github.com/frgfm/torch-cam.git"
 - [IS-CAM](https://arxiv.org/abs/2010.03023)：Score-CAM 的积分变体。
 - [XGrad-CAM](https://arxiv.org/abs/2008.02312)：在敏感性和守恒性方面改进的 Grad-CAM。
 - [Layer-CAM](http://mftp.mmcheng.net/Papers/21TIP_LayerCAM.pdf)：Grad-CAM 的替代方案，利用梯度对激活的逐像素贡献。
+- [RefineCAM](https://arxiv.org/abs/2605.14641)：融合多个网络层以生成高分辨率类激活图。
 
 *不知道该用哪一种？请参阅[如何选择 CAM 方法](https://frgfm.github.io/torch-cam/getting-started/advanced-usage/#choosing-a-cam-method)。*
 

--- a/docs/docs/getting-started/advanced-usage.md
+++ b/docs/docs/getting-started/advanced-usage.md
@@ -86,6 +86,17 @@ with LayerCAM(model, ["layer2", "layer3", "layer4"]) as cam_extractor:
     fused = cam_extractor.fuse_cams(cams)       # single fused map
 ```
 
+`RefineCAM` formalizes multi-layer fusion by normalizing and multiplying the maps. It requires at least two target
+layers and uses `GradCAMpp` as its base method by default. Pass another extractor class to reuse its weighting:
+
+```python
+from torchcam.methods import LayerCAM, RefineCAM
+
+with RefineCAM(model, ["layer2", "layer3", "layer4"], base_method=LayerCAM) as cam_extractor:
+    out = model(input_tensor)
+    refined = cam_extractor(out.squeeze(0).argmax().item(), out)[0]
+```
+
 ## Understanding `class_idx` and the call signature
 
 ```python
@@ -101,7 +112,8 @@ cam_extractor(class_idx, scores=None, normalized=True)
   visualization/overlay. Pass `normalized=False` to get the raw weighted maps, e.g. when comparing magnitudes
   across layers before fusing them yourself.
 - **Returns** a `list` of activation maps, **one tensor per hooked layer**, each of shape `(N, H, W)`. With a
-  single layer and a single image, the map you want is `cams[0].squeeze(0)`.
+  single layer and a single image, the map you want is `cams[0].squeeze(0)`. `RefineCAM` instead returns a
+  one-element list containing its final fused map.
 
 Gradient-based extractors also accept `retain_graph=True` (forwarded to `loss.backward`), needed when you call
 the extractor several times after a single forward — see
@@ -243,6 +255,7 @@ extra spatial dimension). Note that `overlay_mask` works on 2D PIL images, so ov
 | `CAM`                       | no              | cheapest                 | needs global pooling + a **single** `nn.Linear` head (e.g. ResNet); fails on multi-FC heads like VGG |
 | `GradCAM`                   | yes             | one backward pass        | robust default for most CNNs |
 | `LayerCAM`                  | yes             | one backward pass        | best localization in our benchmark; ideal when fusing layers |
+| `RefineCAM`                 | depends on base | base method + cheap fusion | high-resolution fusion across at least two layers; defaults to `GradCAMpp` |
 | `GradCAMpp` / `XGradCAM`    | yes             | one backward pass        | alternative weighting schemes |
 | `SmoothGradCAMpp`           | yes             | `num_samples` forwards   | sharper maps via noise averaging |
 | `ScoreCAM` / `SSCAM` / `ISCAM` | no           | many forwards (slow)     | gradient-free; tune `batch_size`; useful when gradients are unavailable |

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -87,6 +87,7 @@ plt.imshow(result); plt.axis('off'); plt.tight_layout(); plt.show()
    * Smooth Grad-CAM++ from ["Smooth Grad-CAM++: An Enhanced Inference Level Visualization Technique for Deep Convolutional Neural Network Models"](https://arxiv.org/pdf/1908.01224.pdf)
    * X-Grad-CAM from ["Axiom-based Grad-CAM: Towards Accurate Visualization and Explanation of CNNs"](https://arxiv.org/pdf/2008.02312.pdf)
    * Layer-CAM from ["LayerCAM: Exploring Hierarchical Class Activation Maps for Localization"](http://mmcheng.net/mftp/Papers/21TIP_LayerCAM.pdf)
+   * RefineCAM from ["How to Evaluate and Refine your CAM"](https://arxiv.org/abs/2605.14641)
 
 ## Next steps
 

--- a/docs/docs/reference/methods.md
+++ b/docs/docs/reference/methods.md
@@ -46,3 +46,4 @@ Methods related to gradient-based class activation maps.
             - SmoothGradCAMpp
             - XGradCAM
             - LayerCAM
+            - RefineCAM

--- a/tests/test_methods_gradient.py
+++ b/tests/test_methods_gradient.py
@@ -1,9 +1,12 @@
+from functools import partial
+
 import pytest
 import torch
 from torch import nn
 from torchvision.models import get_model
 
-from torchcam.methods import gradient
+from torchcam.methods import activation, gradient
+from torchcam.metrics import ClassificationMetric
 
 
 def _verify_cam(activation_map, output_size):
@@ -11,6 +14,18 @@ def _verify_cam(activation_map, output_size):
     assert isinstance(activation_map, torch.Tensor)
     assert activation_map.shape == output_size
     assert not torch.isnan(activation_map).any()
+
+
+def _tiny_model():
+    return nn.Sequential(
+        nn.Conv2d(3, 4, 3, padding=1),
+        nn.ReLU(),
+        nn.Conv2d(4, 4, 3, padding=1),
+        nn.ReLU(),
+        nn.AdaptiveAvgPool2d((1, 1)),
+        nn.Flatten(1),
+        nn.Linear(4, 3),
+    ).eval()
 
 
 @pytest.mark.parametrize(
@@ -112,6 +127,75 @@ def test_layercam_fuse_cams():
     assert isinstance(cam, torch.Tensor)
     assert cam.ndim == cams[0].ndim
     assert cam.shape == (1, 16, 16)
+
+
+def test_refinecam_fuse_cams():
+    cams = [
+        torch.tensor([[[0.0, 1.0], [2.0, 3.0]]]),
+        torch.tensor([[[3.0, 2.0], [1.0, 0.0]]]),
+    ]
+    originals = [cam.clone() for cam in cams]
+
+    assert torch.allclose(
+        gradient.RefineCAM.fuse_cams(cams, normalized=False),
+        torch.tensor([[[0.0, 2 / 9], [2 / 9, 0.0]]]),
+    )
+    assert torch.allclose(
+        gradient.RefineCAM.fuse_cams(cams),
+        torch.tensor([[[0.0, 1.0], [1.0, 0.0]]]),
+    )
+    assert all(map(torch.equal, cams, originals))
+
+    larger_cam = torch.arange(16, dtype=torch.float32).reshape(1, 4, 4)
+    assert gradient.RefineCAM.fuse_cams([cams[0], larger_cam]).shape == (1, 4, 4)
+    assert gradient.RefineCAM.fuse_cams([cams[0], larger_cam], (2, 2)).shape == (1, 2, 2)
+    assert gradient.RefineCAM.fuse_cams(cams[:1]).shape == cams[0].shape
+
+    volume = torch.arange(8, dtype=torch.float32).reshape(1, 2, 2, 2)
+    assert gradient.RefineCAM.fuse_cams([volume, volume.flip(-1)]).shape == volume.shape
+
+    with pytest.raises(TypeError):
+        gradient.RefineCAM.fuse_cams(torch.zeros((1, 2, 2)))
+    with pytest.raises(ValueError):
+        gradient.RefineCAM.fuse_cams([])
+
+
+@pytest.mark.parametrize("base_method", [gradient.GradCAMpp, gradient.LayerCAM, activation.ScoreCAM])
+def test_refinecam_base_methods(base_method):
+    model = _tiny_model()
+    input_tensor = torch.rand((2, 3, 8, 8))
+
+    with gradient.RefineCAM(model, ["0", "2"], base_method=base_method) as extractor:
+        scores = model(input_tensor)
+        cams = extractor([0, 1], scores)
+        assert len(cams) == 1
+        _verify_cam(cams[0], (2, 8, 8))
+        assert extractor.model is model
+        assert extractor.target_names == ["0", "2"]
+        assert repr(extractor) == f"RefineCAM(base_method={base_method.__name__}, target_layer=['0', '2'])"
+
+    assert extractor.base_cam.hook_handles == []
+
+
+def test_refinecam_metric_compatibility():
+    model = _tiny_model()
+    input_tensor = torch.rand((1, 3, 8, 8))
+
+    with gradient.RefineCAM(model, ["0", "2"]) as extractor:
+        metric = ClassificationMetric(extractor, partial(torch.softmax, dim=-1))
+        metric.update(input_tensor)
+        summary = metric.summary()
+
+    assert set(summary) == {"avg_drop", "conf_increase"}
+
+
+def test_refinecam_rejects_invalid_configuration():
+    model = _tiny_model()
+
+    with pytest.raises(ValueError, match="at least two target layers"):
+        gradient.RefineCAM(model, ["0"])
+    with pytest.raises(TypeError, match="CAM extractor class"):
+        gradient.RefineCAM(model, ["0", "2"], base_method=nn.Module)
 
 
 def test_gradcam_does_not_accumulate_hook_handles(mock_img_tensor):

--- a/torchcam/methods/gradient.py
+++ b/torchcam/methods/gradient.py
@@ -3,15 +3,18 @@
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 
+from contextlib import AbstractContextManager
 from functools import partial
-from typing import Any
+from types import TracebackType
+from typing import Any, Self
 
 import torch
 from torch import Tensor, nn
+from torch.nn import functional as F
 
 from .core import _CAM
 
-__all__ = ["GradCAM", "GradCAMpp", "LayerCAM", "SmoothGradCAMpp", "XGradCAM"]
+__all__ = ["GradCAM", "GradCAMpp", "LayerCAM", "RefineCAM", "SmoothGradCAMpp", "XGradCAM"]
 
 
 class _GradCAM(_CAM):
@@ -453,3 +456,149 @@ class LayerCAM(_GradCAM):
     def _scale_cams(cams: list[Tensor], gamma: float = 2.0) -> list[Tensor]:
         # cf. Equation 9 in the paper
         return [torch.tanh(gamma * cam) for cam in cams]
+
+
+class RefineCAM:
+    r"""Implements the multi-layer refinement described in ["How to Evaluate and Refine your CAM"](
+    https://arxiv.org/abs/2605.14641).
+
+    RefineCAM normalizes class activation maps from multiple layers, resizes them to a common spatial shape, and
+    multiplies them element-wise. Grad-CAM++ is used by default, but any CAM extractor supporting multiple target
+    layers can be passed as ``base_method``.
+
+    Example:
+        ```python
+        from torchvision.models import get_model, get_model_weights
+        from torchcam.methods import LayerCAM, RefineCAM
+        model = get_model("resnet18", weights=get_model_weights("resnet18").DEFAULT).eval()
+        with RefineCAM(model, ["layer2", "layer3", "layer4"], base_method=LayerCAM) as cam_extractor:
+            scores = model(input_tensor)
+            cam = cam_extractor(class_idx=100, scores=scores)[0]
+        ```
+
+    Args:
+        model: input model
+        target_layer: target layers, specified as modules or their names
+        input_shape: shape of the expected input tensor excluding the batch dimension
+        base_method: CAM extractor used to produce the per-layer maps
+        base_kwargs: keyword arguments forwarded to ``base_method``
+    """
+
+    def __init__(
+        self,
+        model: nn.Module,
+        target_layer: list[nn.Module | str],
+        input_shape: tuple[int, ...] = (3, 224, 224),
+        *,
+        base_method: type[_CAM] = GradCAMpp,
+        **base_kwargs: Any,
+    ) -> None:
+        if not isinstance(target_layer, list) or len(target_layer) < 2:
+            raise ValueError("RefineCAM requires at least two target layers")
+        if not isinstance(base_method, type) or not issubclass(base_method, _CAM):
+            raise TypeError("base_method must be a CAM extractor class")
+
+        self.base_cam = base_method(model, target_layer, input_shape=input_shape, **base_kwargs)
+
+    @property
+    def model(self) -> nn.Module:
+        """The model wrapped by the base extractor."""
+        return self.base_cam.model
+
+    @property
+    def target_names(self) -> list[str]:
+        """The target layer names used by the base extractor."""
+        return self.base_cam.target_names
+
+    def enable_hooks(self) -> None:
+        """Enable the base extractor hooks."""
+        self.base_cam.enable_hooks()
+
+    def disable_hooks(self) -> None:
+        """Disable the base extractor hooks."""
+        self.base_cam.disable_hooks()
+
+    def reset_hooks(self) -> None:
+        """Clear the activations and gradients stored by the base extractor."""
+        self.base_cam.reset_hooks()
+
+    def remove_hooks(self) -> None:
+        """Remove the base extractor hooks from the model."""
+        self.base_cam.remove_hooks()
+
+    def _hooks_off(self) -> AbstractContextManager[None]:
+        return self.base_cam._hooks_off()  # noqa: SLF001
+
+    def __enter__(self) -> Self:
+        """Return the RefineCAM context manager."""  # noqa: DOC201
+        return self
+
+    def __exit__(
+        self,
+        exct_type: type[BaseException] | None,
+        exce_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Remove and reset the base extractor hooks."""
+        self.base_cam.__exit__(exct_type, exce_value, traceback)
+
+    def __call__(
+        self,
+        class_idx: int | list[int],
+        scores: Tensor | None = None,
+        normalized: bool = True,
+        target_shape: tuple[int, ...] | None = None,
+        **kwargs: Any,
+    ) -> list[Tensor]:
+        """Compute and refine the per-layer CAMs for an output class."""  # noqa: DOC201
+        cams = self.base_cam(class_idx, scores, normalized=True, **kwargs)
+        return [self.fuse_cams(cams, target_shape, normalized)]
+
+    def compute_cams(
+        self,
+        class_idx: int | list[int],
+        scores: Tensor | None = None,
+        normalized: bool = True,
+        target_shape: tuple[int, ...] | None = None,
+        **kwargs: Any,
+    ) -> list[Tensor]:
+        """Compute and refine CAMs without the base extractor precheck."""  # noqa: DOC201
+        cams = self.base_cam.compute_cams(class_idx, scores, normalized=True, **kwargs)
+        return [self.fuse_cams(cams, target_shape, normalized)]
+
+    @staticmethod
+    @torch.no_grad()
+    def fuse_cams(
+        cams: list[Tensor],
+        target_shape: tuple[int, ...] | None = None,
+        normalized: bool = True,
+    ) -> Tensor:
+        """Normalize, resize, and multiply maps from multiple layers.
+
+        Raises:
+            TypeError: if ``cams`` is not a list of tensors
+            ValueError: if ``cams`` is empty
+        """  # noqa: DOC201
+        if not isinstance(cams, list) or any(not isinstance(cam, Tensor) for cam in cams):
+            raise TypeError("invalid argument type for `cams`")
+        if not cams:
+            raise ValueError("argument `cams` cannot be an empty list")
+
+        shape = target_shape or tuple(map(max, zip(*[tuple(cam.shape[1:]) for cam in cams], strict=True)))
+        interpolation_mode = "bilinear" if cams[0].ndim == 3 else "trilinear" if cams[0].ndim == 4 else "nearest"
+        resize_kwargs = {} if interpolation_mode == "nearest" else {"align_corners": False}
+        resized_cams = [
+            F.interpolate(
+                _CAM._normalize(cam.clone()).unsqueeze(1),  # noqa: SLF001
+                shape,
+                mode=interpolation_mode,
+                **resize_kwargs,
+            )
+            for cam in cams
+        ]
+        refined_cam = torch.stack(resized_cams).prod(dim=0).squeeze(1)
+        return _CAM._normalize(refined_cam) if normalized else refined_cam  # noqa: SLF001
+
+    def __repr__(self) -> str:
+        """Return the RefineCAM representation."""  # noqa: DOC201
+        return f"RefineCAM(base_method={self.base_cam.__class__.__name__}, target_layer={self.target_names})"

--- a/torchcam/metrics.py
+++ b/torchcam/metrics.py
@@ -4,11 +4,26 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 
 from collections.abc import Callable
-from typing import cast
+from contextlib import AbstractContextManager
+from typing import Any, Protocol, cast
 
 import torch
 
-from .methods.core import _CAM
+
+class _CAMExtractor(Protocol):
+    model: torch.nn.Module
+
+    def __call__(
+        self,
+        class_idx: int | list[int],
+        scores: torch.Tensor | None = None,
+        normalized: bool = True,
+        **kwargs: Any,
+    ) -> list[torch.Tensor]: ...
+
+    def fuse_cams(self, cams: list[torch.Tensor]) -> torch.Tensor: ...
+
+    def _hooks_off(self) -> AbstractContextManager[None]: ...
 
 
 class ClassificationMetric:
@@ -59,7 +74,7 @@ class ClassificationMetric:
 
     def __init__(
         self,
-        cam_extractor: _CAM,
+        cam_extractor: _CAMExtractor,
         logits_fn: Callable[[torch.Tensor], torch.Tensor] | None = None,
     ) -> None:
         # This is a typa, I don't know how to rites


### PR DESCRIPTION
## Summary

- add a generic RefineCAM composition wrapper with GradCAM++ as the default base
- normalize, resize, and multiply multi-layer maps with one base extractor and native tensors
- delegate extractor lifecycle and support ClassificationMetric through a private protocol
- document RefineCAM in the API, method chooser, and English and Chinese CAM zoos

## Validation

- uv run pytest tests/test_methods_gradient.py -q: 22 passed
- make test: 58 passed
- make quality: passed
- DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/opt/cairo/lib:/opt/homebrew/lib uv run --extra docs mkdocs build --strict --config-file docs/mkdocs.yml: passed
- git diff --check: passed

## Full Imagenette comparison

Hardware: Apple M3 Pro MacBook Pro, 11 CPU cores, 36 GB RAM, macOS 15.7.7, PyTorch 2.13.0, MPS.
Dataset: full Imagenette validation set, 3,925 images, 224 x 224 inputs.
Common options: --arch resnet18 --device mps --batch-size 32 --workers 8.

| Method | Target layers | Average Drop | Increase in Confidence | Skipped | Time |
|---|---|---:|---:|---:|---:|
| RefineCAM | layer2,layer3,layer4 | 70.47% | 2.96% | 0 | 106.8 s |
| GradCAMpp | layer4 | 52.71% | 19.62% | 0 | 99.4 s |
| LayerCAM | layer2,layer3,layer4 | 8.45% | 43.85% | 0 | 100.2 s |

Commands:

    uv run python scripts/eval_perf.py /Users/fg/Documents/datasets/imagenette2-320 RefineCAM --arch resnet18 --target layer2,layer3,layer4 --device mps --batch-size 32 --workers 8
    uv run python scripts/eval_perf.py /Users/fg/Documents/datasets/imagenette2-320 GradCAMpp --arch resnet18 --target layer4 --device mps --batch-size 32 --workers 8
    uv run python scripts/eval_perf.py /Users/fg/Documents/datasets/imagenette2-320 LayerCAM --arch resnet18 --target layer2,layer3,layer4 --device mps --batch-size 32 --workers 8

These results are machine-specific comparative evidence, not a merge threshold or universal SOTA claim. RefineCAM underperformed both baselines on this configuration; the implementation tests establish formula and integration correctness, not scientific superiority.