### PR TITLE
feat(methods): add LeGrad

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ This project is developed and maintained by the repo owner, but the implementati
 - [XGrad-CAM](https://arxiv.org/abs/2008.02312): improved version of Grad-CAM in terms of sensitivity and conservation.
 - [Layer-CAM](http://mftp.mmcheng.net/Papers/21TIP_LayerCAM.pdf): Grad-CAM alternative leveraging pixel-wise contribution of the gradient to the activation.
 - [Finer-CAM](https://arxiv.org/abs/2501.11309): contrastive CAM objective highlighting differences between similar classes.
+- [LeGrad](https://arxiv.org/abs/2404.03214): layerwise positive attention-gradient maps for Vision Transformers.
 - [RefineCAM](https://arxiv.org/abs/2605.14641): multi-layer refinement producing high-resolution activation maps.
 
 *Not sure which one to use? See [Choosing a CAM method](https://frgfm.github.io/torch-cam/getting-started/advanced-usage/#choosing-a-cam-method).*

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -168,6 +168,7 @@ pip install "torchcam @ git+https://github.com/frgfm/torch-cam.git"
 - [XGrad-CAM](https://arxiv.org/abs/2008.02312)：在敏感性和守恒性方面改进的 Grad-CAM。
 - [Layer-CAM](http://mftp.mmcheng.net/Papers/21TIP_LayerCAM.pdf)：Grad-CAM 的替代方案，利用梯度对激活的逐像素贡献。
 - [Finer-CAM](https://arxiv.org/abs/2501.11309)：通过对比相似类别突出细粒度差异的 CAM 目标。
+- [LeGrad](https://arxiv.org/abs/2404.03214)：利用视觉 Transformer 各层注意力概率的正梯度生成解释图。
 - [RefineCAM](https://arxiv.org/abs/2605.14641)：融合多个网络层以生成高分辨率类激活图。
 
 *不知道该用哪一种？请参阅[如何选择 CAM 方法](https://frgfm.github.io/torch-cam/getting-started/advanced-usage/#choosing-a-cam-method)。*

--- a/docs/docs/getting-started/advanced-usage.md
+++ b/docs/docs/getting-started/advanced-usage.md
@@ -14,7 +14,8 @@ what your model accepts and returns:
 | CNN classifier | Native | Class logits shaped `(N, num_classes)` and a spatial target layer. |
 | Batched, 3D, or video classifier | Native | One class index per sample and the correct `input_shape`. |
 | Multi-input model or tuple/dict output | Adapter required | Wrap the model so the hooked path returns one logits tensor. |
-| ViT or Swin classifier | Adapter required | Set `target_layer` and reshape tokens with `reshape_transform`. |
+| torchvision VisionTransformer | Native with `LeGrad` | Target supported encoder blocks; other CAM methods need `reshape_transform`. |
+| Other ViT or Swin classifier | Adapter required | Set `target_layer` and reshape tokens with `reshape_transform`; `LeGrad` only supports the contract below. |
 | Detection, segmentation, generative, or non-scalar output | Not supported out of the box | Adapt the model and define the scalar class target to explain. |
 
 ## Use your own model
@@ -132,15 +133,15 @@ cam_extractor(class_idx, scores=None, normalized=True)
   To explain the top prediction use the argmax (`out.squeeze(0).argmax().item()`), but you can pass **any** valid
   index to see where the model looks for that class. For a batch, pass one index per sample (see below).
 - **`scores`** — the raw model output of shape `(N, num_classes)`. Required by the gradient-based methods (used
-  for backprop) and by the Score-CAM family; ignored by `SmoothGradCAMpp` and `CAM`.
+  for backprop) and by the Score-CAM family; ignored by `LeGrad`, `SmoothGradCAMpp`, and `CAM`.
 - **`normalized`** — when `True` (default) each map is min-max normalized to `[0, 1]`, which is what you want for
   visualization/overlay. Pass `normalized=False` to get the raw weighted maps, e.g. when comparing magnitudes
   across layers before fusing them yourself.
 - **Returns** a `list` of activation maps, **one tensor per hooked layer**, each of shape `(N, H, W)`. With a
-  single layer and a single image, the map you want is `cams[0].squeeze(0)`. `RefineCAM` instead returns a
-  one-element list containing its final fused map.
+  single layer and a single image, the map you want is `cams[0].squeeze(0)`. `LeGrad` and `RefineCAM` instead
+  return a one-element list containing their final fused map.
 
-Gradient-based extractors also accept `retain_graph=True` (forwarded to `loss.backward`), needed when you call
+Gradient-based extractors also accept `retain_graph=True` (forwarded to the gradient computation), needed when you call
 the extractor several times after a single forward — see
 [Troubleshooting](troubleshooting.md#runtimeerror-trying-to-backward-through-the-graph-a-second-time).
 
@@ -255,6 +256,53 @@ This enables activation- and gradient-based extractors such as `LayerCAM`, `Grad
 weight-based `CAM` method still requires its global-pooling and classifier-weight assumptions, which standard ViTs
 do not satisfy. Attention rollout or attention flow are separate transformer-specific explanation techniques.
 
+### LeGrad for torchvision Vision Transformers
+
+[`LeGrad`](../reference/methods.md#torchcam.methods.LeGrad) uses the positive gradient of each layer-specific class
+score with respect to the post-softmax attention probabilities. For layer $l$, head $h$, query $q$, and key $k$:
+
+$$
+E^l_k = \frac{1}{H Q} \sum_{h,q} \operatorname{ReLU}\left(\frac{\partial s^l}{\partial A^l_{h,q,k}}\right),
+\qquad
+E = \operatorname{normalize}\left(\frac{1}{L} \sum_l \operatorname{reshape}(E^l_{\text{patch keys}})\right).
+$$
+
+LeGrad does **not** multiply gradients by attention values. That multiplication is AttentionCAM. It also differs
+from GradCAM-on-tokens, which weights token activations, and attention rollout, which multiplies attention matrices
+across layers.
+
+For torchvision `VisionTransformer`, target complete encoder blocks. The default layer score averages that block's
+tokens, then applies `model.encoder.ln` and `model.heads` as the shared classifier projection:
+
+```python
+from torchvision.models import ViT_B_16_Weights, vit_b_16
+from torchcam.methods import LeGrad
+
+weights = ViT_B_16_Weights.DEFAULT
+model = vit_b_16(weights=weights).eval()
+input_tensor = weights.transforms()(image).unsqueeze(0)
+target_layers = list(model.encoder.layers)[-4:]
+
+with LeGrad(model, target_layers, prefix_tokens=1) as extractor:
+    scores = model(input_tensor)
+    cam = extractor(scores[0].argmax().item())[0]
+```
+
+The 196 patch keys form a square 14×14 grid, so `grid_shape` is inferred. Pass `grid_shape=(height, width)` for a
+non-square patch layout. Custom models must provide `score_projection(tokens) -> logits` and meet every condition
+below:
+
+| Requirement | Supported contract |
+| --- | --- |
+| Target output | One tensor shaped `(batch, tokens, embedding)`. |
+| Attention | Direct `self_attention` child using batch-first, shared-dimension `nn.MultiheadAttention`. |
+| Attention mode | Self-attention without added key/value tokens or active attention dropout. |
+| Prefix/grid | Configurable prefix count; square grid inferred or non-square grid specified explicitly. |
+
+Swin, timm, OpenCLIP, cross-attention, attentional poolers, and arbitrary transformer layouts are not supported by
+this initial implementation. Run the model with gradient tracking enabled; `torch.no_grad()` and
+`torch.inference_mode()` cannot produce LeGrad maps.
+
 ## 3D and video models
 
 Volumetric inputs work out of the box: set `input_shape` to your 3D input shape as `(C, D, H, W)` (i.e. excluding
@@ -281,6 +329,7 @@ extra spatial dimension). Note that `overlay_mask` works on 2D PIL images, so ov
 | `GradCAM`                   | yes             | one backward pass        | robust default for most CNNs |
 | `LayerCAM`                  | yes             | one backward pass        | best localization in our benchmark; ideal when fusing layers |
 | `FinerCAM`                  | yes             | one backward pass        | contrastive fine-grained cues with `GradCAM`, `GradCAMpp`, or `LayerCAM` |
+| `LeGrad`                    | yes             | one gradient per selected layer | attention-gradient maps for supported torchvision-style ViTs |
 | `RefineCAM`                 | depends on base | base method + cheap fusion | high-resolution fusion across at least two layers; defaults to `GradCAMpp` |
 | `GradCAMpp` / `XGradCAM`    | yes             | one backward pass        | alternative weighting schemes |
 | `SmoothGradCAMpp`           | yes             | `num_samples` forwards   | sharper maps via noise averaging |

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -87,6 +87,7 @@ plt.imshow(result); plt.axis('off'); plt.tight_layout(); plt.show()
    * Smooth Grad-CAM++ from ["Smooth Grad-CAM++: An Enhanced Inference Level Visualization Technique for Deep Convolutional Neural Network Models"](https://arxiv.org/pdf/1908.01224.pdf)
    * X-Grad-CAM from ["Axiom-based Grad-CAM: Towards Accurate Visualization and Explanation of CNNs"](https://arxiv.org/pdf/2008.02312.pdf)
    * Layer-CAM from ["LayerCAM: Exploring Hierarchical Class Activation Maps for Localization"](http://mmcheng.net/mftp/Papers/21TIP_LayerCAM.pdf)
+   * LeGrad from ["LeGrad: An Explainability Method for Vision Transformers via Feature Formation Sensitivity"](https://arxiv.org/abs/2404.03214)
    * RefineCAM from ["How to Evaluate and Refine your CAM"](https://arxiv.org/abs/2605.14641)
 
 ## Next steps

--- a/docs/docs/reference/methods.md
+++ b/docs/docs/reference/methods.md
@@ -47,4 +47,5 @@ Methods related to gradient-based class activation maps.
             - SmoothGradCAMpp
             - XGradCAM
             - LayerCAM
+            - LeGrad
             - RefineCAM

--- a/tests/test_methods_transformer.py
+++ b/tests/test_methods_transformer.py
@@ -1,8 +1,15 @@
+import copy
+from contextlib import nullcontext
+from functools import partial
+
 import pytest
 import torch
+from torch import nn
+from torch.nn import functional as F
 from torchvision.models.vision_transformer import VisionTransformer
 
-from torchcam.methods import LayerCAM, ScoreCAM
+from torchcam.methods import LayerCAM, LeGrad, ScoreCAM
+from torchcam.metrics import ClassificationMetric
 
 
 def _build_vit() -> VisionTransformer:
@@ -70,3 +77,466 @@ def test_scorecam_with_reshape_transform():
         assert cam.shape == (1, 4, 4)
         assert torch.isfinite(cam).all()
         assert cam.std() > 0
+
+
+class _TinyBlock(nn.Module):
+    def __init__(
+        self,
+        hidden_dim=8,
+        num_heads=2,
+        *,
+        batch_first=True,
+        attention_dropout=0.0,
+        add_bias_kv=False,
+        add_zero_attn=False,
+    ):
+        super().__init__()
+        self.ln_1 = nn.LayerNorm(hidden_dim)
+        self.self_attention = nn.MultiheadAttention(
+            hidden_dim,
+            num_heads,
+            dropout=attention_dropout,
+            batch_first=batch_first,
+            add_bias_kv=add_bias_kv,
+            add_zero_attn=add_zero_attn,
+        )
+        self.ln_2 = nn.LayerNorm(hidden_dim)
+        self.mlp = nn.Sequential(
+            nn.Linear(hidden_dim, hidden_dim * 2), nn.GELU(), nn.Linear(hidden_dim * 2, hidden_dim)
+        )
+
+    def forward(self, input_tensor):
+        x = self.ln_1(input_tensor)
+        x, _ = self.self_attention(x, x, x, need_weights=False)
+        x += input_tensor
+        return x + self.mlp(self.ln_2(x))
+
+
+class _CrossAttentionBlock(_TinyBlock):
+    def forward(self, input_tensor):
+        x = self.ln_1(input_tensor)
+        memory = x.roll(1, dims=1)
+        x, _ = self.self_attention(x, memory, memory, need_weights=False)
+        x += input_tensor
+        return x + self.mlp(self.ln_2(x))
+
+
+class _PositionalAttentionBlock(_TinyBlock):
+    def forward(self, input_tensor):
+        x = self.ln_1(input_tensor)
+        x, _ = self.self_attention(x, x, x, None, False, None, True)
+        x += input_tensor
+        return x + self.mlp(self.ln_2(x))
+
+
+class _InvalidOutputBlock(_TinyBlock):
+    def forward(self, input_tensor):
+        return super().forward(input_tensor).mean(dim=1)
+
+
+class _DropTokenBlock(_TinyBlock):
+    def forward(self, input_tensor):
+        return super().forward(input_tensor)[:, :-1]
+
+
+class _NoWeightsAttention(nn.MultiheadAttention):
+    def forward(self, *args, **kwargs):
+        output, _ = super().forward(*args, **kwargs)
+        return output, None
+
+
+class _AveragedWeightsAttention(nn.MultiheadAttention):
+    def forward(self, *args, **kwargs):
+        output, weights = super().forward(*args, **kwargs)
+        assert isinstance(weights, torch.Tensor)
+        return output, weights.mean(dim=1)
+
+
+class _ShortWeightsAttention(nn.MultiheadAttention):
+    def forward(self, *args, **kwargs):
+        output, weights = super().forward(*args, **kwargs)
+        assert isinstance(weights, torch.Tensor)
+        return output, weights[..., :-1]
+
+
+def _separate_projection_block():
+    block = _TinyBlock()
+    block.self_attention = nn.MultiheadAttention(8, 2, kdim=4, vdim=4, batch_first=True)
+    return block
+
+
+class _TinyViT(nn.Module):
+    def __init__(self, grid_shape=(2, 2), prefix_tokens=1, num_layers=2, *, attention_dropout=0.0):
+        super().__init__()
+        self.grid_shape = grid_shape
+        self.patch_embed = nn.Conv2d(3, 8, 1)
+        self.prefix = nn.Parameter(torch.randn(1, prefix_tokens, 8))
+        self.blocks = nn.ModuleList([_TinyBlock(attention_dropout=attention_dropout) for _ in range(num_layers)])
+        self.norm = nn.LayerNorm(8)
+        self.head = nn.Linear(8, 3)
+
+    def project(self, tokens):
+        return self.head(self.norm(tokens.mean(dim=1)))
+
+    def forward(self, input_tensor):
+        tokens = self.patch_embed(input_tensor).flatten(2).transpose(1, 2)
+        tokens = torch.cat((self.prefix.expand(tokens.shape[0], -1, -1), tokens), dim=1)
+        for block in self.blocks:
+            tokens = block(tokens)
+        return self.project(tokens)
+
+
+def _manual_forward(model, input_tensor):
+    tokens = model.patch_embed(input_tensor).flatten(2).transpose(1, 2)
+    tokens = torch.cat((model.prefix.expand(tokens.shape[0], -1, -1), tokens), dim=1)
+    attentions, layer_scores = [], []
+
+    for block in model.blocks:
+        normalized = block.ln_1(tokens)
+        attention = block.self_attention
+        q, k, v = F.linear(normalized, attention.in_proj_weight, attention.in_proj_bias).chunk(3, dim=-1)
+        batch_size, token_count, embed_dim = q.shape
+        head_dim = embed_dim // attention.num_heads
+        q = q.reshape(batch_size, token_count, attention.num_heads, head_dim).transpose(1, 2)
+        k = k.reshape(batch_size, token_count, attention.num_heads, head_dim).transpose(1, 2)
+        v = v.reshape(batch_size, token_count, attention.num_heads, head_dim).transpose(1, 2)
+        probabilities = torch.softmax(torch.matmul(q, k.transpose(-2, -1)) / head_dim**0.5, dim=-1)
+        output = torch.matmul(probabilities, v).transpose(1, 2).reshape(batch_size, token_count, embed_dim)
+        output = attention.out_proj(output)
+        x = tokens + output
+        tokens = x + block.mlp(block.ln_2(x))
+        attentions.append(probabilities)
+        layer_scores.append(model.project(tokens))
+
+    return model.project(tokens), attentions, layer_scores
+
+
+def _manual_legrad(model, input_tensor, class_idx, target_indices, prefix_tokens, grid_shape):
+    output, attentions, layer_scores = _manual_forward(model, input_tensor)
+    maps = []
+    for idx, layer_idx in enumerate(target_indices):
+        scores = layer_scores[layer_idx]
+        selected = (
+            scores[:, class_idx]
+            if isinstance(class_idx, int)
+            else scores.gather(1, torch.tensor(class_idx).view(-1, 1)).squeeze(1)
+        )
+        grad = torch.autograd.grad(selected.sum(), attentions[layer_idx], retain_graph=idx < len(target_indices) - 1)[0]
+        relevance = grad.relu().mean(dim=(1, 2))[:, prefix_tokens:]
+        maps.append(relevance.reshape(relevance.shape[0], *grid_shape))
+
+    cam = torch.stack(maps).mean(dim=0)
+    cam -= cam.flatten(1).min(dim=-1).values[:, None, None]
+    cam /= cam.flatten(1).max(dim=-1).values[:, None, None] + 1e-8
+    return output, [attentions[idx] for idx in target_indices], cam
+
+
+@pytest.mark.parametrize(
+    ("grid_shape", "prefix_tokens", "target_indices", "batch_size", "class_idx", "infer_grid"),
+    [
+        ((2, 2), 1, [0], 1, 1, True),
+        ((2, 3), 2, [0, 1], 2, [0, 2], False),
+    ],
+)
+def test_legrad_matches_manual_oracle(
+    grid_shape,
+    prefix_tokens,
+    target_indices,
+    batch_size,
+    class_idx,
+    infer_grid,
+):
+    torch.manual_seed(0)
+    model = _TinyViT(grid_shape, prefix_tokens)
+    oracle_model = copy.deepcopy(model)
+    input_tensor = torch.randn(batch_size, 3, *grid_shape)
+    expected_scores, expected_attention, expected_cam = _manual_legrad(
+        oracle_model,
+        input_tensor,
+        class_idx,
+        target_indices,
+        prefix_tokens,
+        grid_shape,
+    )
+
+    targets = [model.blocks[idx] for idx in target_indices]
+    with LeGrad(
+        model,
+        targets,
+        score_projection=model.project,
+        prefix_tokens=prefix_tokens,
+        grid_shape=None if infer_grid else grid_shape,
+    ) as extractor:
+        scores = model(input_tensor)
+        cam = extractor(class_idx, torch.full_like(scores, 1e6), retain_graph=True)[0]
+
+        assert torch.allclose(scores, expected_scores, atol=1e-6, rtol=1e-5)
+        assert torch.allclose(cam, expected_cam, atol=1e-6, rtol=1e-5)
+        for idx, (attention, expected) in enumerate(zip(extractor.hook_attn, expected_attention, strict=True)):
+            assert isinstance(attention, torch.Tensor)
+            assert torch.allclose(attention, expected, atol=1e-6, rtol=1e-5)
+            assert torch.allclose(attention.sum(dim=-1), torch.ones_like(attention[..., 0]))
+            assert torch.autograd.grad(extractor.hook_a[idx].sum(), attention, retain_graph=True)[0] is not None
+
+
+def test_legrad_torchvision_vit_repeated_calls_and_frozen_parameters():
+    model = _build_vit().double()
+    for parameter in model.parameters():
+        parameter.requires_grad_(False)
+    flags = [parameter.requires_grad for parameter in model.parameters()]
+    state = {name: value.clone() for name, value in model.state_dict().items()}
+    input_tensor = torch.randn(2, 3, 32, 32, dtype=torch.float64)
+
+    with LeGrad(model, list(model.encoder.layers)) as extractor:
+        for _ in range(2):
+            scores = model(input_tensor)
+            cam = extractor([0, 1], scores)[0]
+            assert cam.shape == (2, 4, 4)
+            assert cam.dtype == input_tensor.dtype
+            assert cam.device == input_tensor.device
+            assert torch.isfinite(cam).all()
+
+    assert flags == [parameter.requires_grad for parameter in model.parameters()]
+    assert all(parameter.grad is None for parameter in model.parameters())
+    assert all(torch.equal(value, model.state_dict()[name]) for name, value in state.items())
+
+
+def test_legrad_classification_metric_compatibility():
+    model = _build_vit()
+    input_tensor = torch.randn(1, 3, 32, 32)
+
+    with LeGrad(model, model.encoder.layers[-1]) as extractor:
+        metric = ClassificationMetric(extractor, partial(torch.softmax, dim=-1))
+        metric.update(input_tensor)
+        assert set(metric.summary()) == {"avg_drop", "conf_increase"}
+
+
+@pytest.mark.parametrize("raise_inside", [False, True])
+def test_legrad_restores_model_and_hooks(raise_inside):
+    model = _TinyViT().train()
+    for idx, parameter in enumerate(model.parameters()):
+        parameter.requires_grad_(idx % 2 == 0)
+    attention = model.blocks[0].self_attention
+    forward = attention.forward.__func__
+    training = [module.training for module in model.modules()]
+    flags = [parameter.requires_grad for parameter in model.parameters()]
+    pre_hooks = len(attention._forward_pre_hooks)
+    forward_hooks = len(attention._forward_hooks)
+
+    expectation = pytest.raises(RuntimeError, match="boom") if raise_inside else nullcontext()
+    with expectation, LeGrad(model, model.blocks[0], score_projection=model.project) as extractor:
+        assert attention.forward.__func__ is forward
+        if raise_inside:
+            raise RuntimeError("boom")
+        scores = model(torch.randn(1, 3, 2, 2))
+        assert torch.isfinite(extractor(0, scores)[0]).all()
+
+    assert attention.forward.__func__ is forward
+    assert len(attention._forward_pre_hooks) == pre_hooks
+    assert len(attention._forward_hooks) == forward_hooks
+    assert training == [module.training for module in model.modules()]
+    assert flags == [parameter.requires_grad for parameter in model.parameters()]
+
+
+@pytest.mark.parametrize(
+    ("target_factory", "exception", "error"),
+    [
+        (nn.Identity, TypeError, "self_attention"),
+        (partial(_TinyBlock, batch_first=False), ValueError, "batch-first"),
+        (_separate_projection_block, ValueError, "shared-dimension"),
+        (partial(_TinyBlock, add_bias_kv=True), ValueError, "added attention tokens"),
+        (partial(_TinyBlock, add_zero_attn=True), ValueError, "added attention tokens"),
+    ],
+)
+def test_legrad_rejects_unsupported_target_blocks(target_factory, exception, error):
+    model = _TinyViT()
+    model.blocks[0] = target_factory()
+    with pytest.raises(exception, match=error):
+        LeGrad(model, model.blocks[0], score_projection=model.project)
+
+
+def test_legrad_rejects_invalid_configuration():
+    model = _TinyViT(grid_shape=(2, 3))
+
+    with pytest.raises(ValueError, match="score_projection"):
+        LeGrad(model, model.blocks[0])
+    with pytest.raises(ValueError, match="explicit target"):
+        LeGrad(model, [], score_projection=model.project)
+    with pytest.raises(TypeError, match="integer"):
+        LeGrad(model, model.blocks[0], score_projection=model.project, prefix_tokens=1.0)
+    with pytest.raises(ValueError, match="non-negative"):
+        LeGrad(model, model.blocks[0], score_projection=model.project, prefix_tokens=-1)
+    with pytest.raises(TypeError, match="tuple of two integers"):
+        LeGrad(model, model.blocks[0], score_projection=model.project, grid_shape=[2, 3])
+    with pytest.raises(ValueError, match="positive"):
+        LeGrad(model, model.blocks[0], score_projection=model.project, grid_shape=(2, 0))
+    with pytest.raises(TypeError, match="callable"):
+        LeGrad(model, model.blocks[0], score_projection=object())
+
+    with LeGrad(model, model.blocks[0], score_projection=model.project) as extractor:
+        scores = model(torch.randn(1, 3, 2, 3))
+        with pytest.raises(ValueError, match="square patch grid"):
+            extractor(0, scores)
+
+    with LeGrad(model, model.blocks[0], score_projection=model.project, grid_shape=(2, 2)) as extractor:
+        scores = model(torch.randn(1, 3, 2, 3))
+        with pytest.raises(ValueError, match="does not match"):
+            extractor(0, scores)
+
+    with LeGrad(model, model.blocks[0], score_projection=model.project, prefix_tokens=7) as extractor:
+        scores = model(torch.randn(1, 3, 2, 3))
+        with pytest.raises(ValueError, match="at least one patch"):
+            extractor(0, scores)
+
+
+def test_legrad_supports_positional_attention_options():
+    model = _TinyViT()
+    model.blocks[0] = _PositionalAttentionBlock()
+    input_tensor = torch.randn(1, 3, 2, 2)
+
+    with LeGrad(model, model.blocks[0], score_projection=model.project) as extractor:
+        scores = model(input_tensor)
+        assert torch.isfinite(extractor(0, scores)[0]).all()
+
+
+def test_legrad_rejects_invalid_attention_inputs():
+    model = _TinyViT()
+    attention = model.blocks[0].self_attention
+    query = torch.randn(1, 5, 8)
+
+    with LeGrad(model, model.blocks[0], score_projection=model.project):
+        with pytest.raises(ValueError, match="tensor query"):
+            attention(query, None, query)
+        unbatched = query.squeeze(0)
+        with pytest.raises(ValueError, match="batch, tokens, embedding"):
+            attention(unbatched, unbatched, unbatched)
+
+
+def test_legrad_rejects_disconnected_scores_and_invalid_forward_modes():
+    model = _TinyViT(attention_dropout=0.1).train()
+    input_tensor = torch.randn(1, 3, 2, 2)
+    with LeGrad(model, model.blocks[0], score_projection=model.project), pytest.raises(ValueError, match="dropout"):
+        model(input_tensor)
+
+    model = _TinyViT()
+    with (
+        LeGrad(model, model.blocks[0], score_projection=model.project),
+        pytest.raises(RuntimeError, match="gradient tracking"),
+        torch.inference_mode(),
+    ):
+        model(input_tensor)
+
+    def disconnected(tokens):
+        return model.project(tokens.detach())
+
+    with LeGrad(model, model.blocks[0], score_projection=disconnected) as extractor:
+        scores = model(input_tensor)
+        with pytest.raises(RuntimeError, match="not connected"):
+            extractor(0, scores)
+
+    with (
+        LeGrad(model, model.blocks[0], score_projection=lambda tokens: tokens.mean()),
+        pytest.raises(ValueError, match="class logits"),
+    ):
+        model(input_tensor)
+
+
+def test_legrad_rejects_cross_attention():
+    input_tensor = torch.randn(1, 3, 2, 2)
+    model = _TinyViT()
+    model.blocks[0] = _CrossAttentionBlock()
+    with (
+        LeGrad(model, model.blocks[0], score_projection=model.project),
+        pytest.raises(ValueError, match="self-attention"),
+    ):
+        model(input_tensor)
+
+
+@pytest.mark.parametrize(
+    ("attention_type", "error"),
+    [
+        (_NoWeightsAttention, "per-head attention probabilities"),
+        (_AveragedWeightsAttention, "probabilities shaped"),
+        (_ShortWeightsAttention, "incompatible attention probability shape"),
+    ],
+)
+def test_legrad_rejects_incompatible_attention_outputs(attention_type, error):
+    model = _TinyViT()
+    model.blocks[0].self_attention = attention_type(8, 2, batch_first=True)
+    with (
+        LeGrad(model, model.blocks[0], score_projection=model.project),
+        pytest.raises(ValueError, match=error),
+    ):
+        model(torch.randn(1, 3, 2, 2))
+
+
+@pytest.mark.parametrize(
+    ("block_type", "error", "during_forward"),
+    [
+        (_InvalidOutputBlock, "target blocks must return tokens", True),
+        (_DropTokenBlock, "attention keys and target-block tokens", False),
+    ],
+)
+def test_legrad_rejects_incompatible_block_outputs(block_type, error, during_forward):
+    model = _TinyViT()
+    model.blocks[0] = block_type()
+    input_tensor = torch.randn(1, 3, 2, 2)
+
+    with LeGrad(model, model.blocks[0], score_projection=model.project) as extractor:
+        if during_forward:
+            with pytest.raises(ValueError, match=error):
+                model(input_tensor)
+        else:
+            scores = model(input_tensor)
+            with pytest.raises(ValueError, match=error):
+                extractor(0, scores)
+
+
+def test_legrad_rejects_missing_captured_state():
+    model = _TinyViT()
+    input_tensor = torch.randn(1, 3, 2, 2)
+
+    with LeGrad(model, model.blocks[0], score_projection=model.project) as extractor:
+        scores = model(input_tensor)
+        extractor.hook_attn[0] = None
+        with pytest.raises(AssertionError, match="every LeGrad target block"):
+            extractor(0, scores)
+
+    with LeGrad(model, model.blocks[0], score_projection=model.project) as extractor:
+        scores = model(input_tensor)
+        extractor.hook_a[0] = None
+        with pytest.raises(AssertionError, match="every LeGrad target block"):
+            extractor.compute_cams(0, scores)
+
+
+def test_legrad_rejects_missing_attention_return_options():
+    model = _TinyViT()
+    block = model.blocks[0]
+    query = torch.randn(1, 5, 8)
+
+    with LeGrad(model, block, score_projection=model.project) as extractor:
+        model(torch.randn(1, 3, 2, 2))
+        attention = extractor.hook_attn[0]
+        assert isinstance(attention, torch.Tensor)
+        extractor._weight_options[0] = None
+        with pytest.raises(RuntimeError, match="missing original attention return options"):
+            extractor._capture_attention(
+                block.self_attention,
+                (query, query, query),
+                {},
+                (query, attention),
+            )
+
+
+def test_legrad_remove_hooks_restores_attention():
+    model = _TinyViT()
+    attention = model.blocks[0].self_attention
+    pre_hooks = len(attention._forward_pre_hooks)
+    forward_hooks = len(attention._forward_hooks)
+    extractor = LeGrad(model, model.blocks[0], score_projection=model.project)
+
+    extractor.remove_hooks()
+
+    assert len(attention._forward_pre_hooks) == pre_hooks
+    assert len(attention._forward_hooks) == forward_hooks
+    assert extractor.hook_handles == []

--- a/torchcam/methods/gradient.py
+++ b/torchcam/methods/gradient.py
@@ -3,9 +3,10 @@
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 
+from collections.abc import Callable
 from contextlib import AbstractContextManager
 from functools import partial
-from math import isfinite
+from math import isfinite, isqrt
 from types import TracebackType
 from typing import Any, Self, cast
 
@@ -15,7 +16,7 @@ from torch.nn import functional as F
 
 from .core import _CAM
 
-__all__ = ["FinerCAM", "GradCAM", "GradCAMpp", "LayerCAM", "RefineCAM", "SmoothGradCAMpp", "XGradCAM"]
+__all__ = ["FinerCAM", "GradCAM", "GradCAMpp", "LayerCAM", "LeGrad", "RefineCAM", "SmoothGradCAMpp", "XGradCAM"]
 
 
 class _GradCAM(_CAM):
@@ -505,6 +506,316 @@ class _CAMWrapper:
         traceback: TracebackType | None,
     ) -> None:
         self.base_cam.__exit__(exct_type, exce_value, traceback)
+
+
+class LeGrad(_CAM):
+    r"""Implements LeGrad as described in ["LeGrad: An Explainability Method for Vision Transformers via Feature
+    Formation Sensitivity"](https://arxiv.org/abs/2404.03214).
+
+    For every selected transformer block :math:`l`, LeGrad differentiates that block's class score
+    :math:`s^l` with respect to its post-softmax attention probabilities :math:`A^l`. Positive gradients are
+    averaged over heads and query tokens, prefix keys are removed, and the resulting patch maps are averaged over
+    layers before normalization. Attention values are not multiplied into the gradients.
+
+    Target layers must return tokens shaped ``(batch, tokens, embedding)`` and expose a direct
+    ``self_attention`` child implemented by batch-first :class:`torch.nn.MultiheadAttention`. The built-in score
+    projection supports torchvision ``VisionTransformer`` models; other matching blocks require
+    ``score_projection`` to map intermediate tokens to class logits.
+
+    Example:
+        ```python
+        from torchvision.models import ViT_B_16_Weights, vit_b_16
+        from torchcam.methods import LeGrad
+
+        model = vit_b_16(weights=ViT_B_16_Weights.DEFAULT).eval()
+        with LeGrad(model, list(model.encoder.layers)[-4:]) as cam_extractor:
+            scores = model(input_tensor)
+            cam = cam_extractor(scores[0].argmax().item())[0]
+        ```
+
+    Args:
+        model: input model
+        target_layer: transformer block or blocks, specified as modules or their names
+        score_projection: optional function mapping intermediate tokens to class logits shaped ``(N, C)``
+        prefix_tokens: number of non-spatial key tokens to remove before reshaping
+        grid_shape: patch-grid ``(height, width)``; inferred when the patch count is a perfect square
+        enable_hooks: whether hooks should be enabled by default
+
+    Raises:
+        TypeError: if an argument has an invalid type
+        ValueError: if the model, target blocks, attention modules, or grid are unsupported
+    """
+
+    def __init__(
+        self,
+        model: nn.Module,
+        target_layer: nn.Module | str | list[nn.Module | str],
+        *,
+        score_projection: Callable[[Tensor], Tensor] | None = None,
+        prefix_tokens: int = 1,
+        grid_shape: tuple[int, int] | None = None,
+        enable_hooks: bool = True,
+    ) -> None:
+        if target_layer is None or (isinstance(target_layer, list) and not target_layer):
+            raise ValueError("LeGrad requires at least one explicit target block")
+        self._validate_init_args(prefix_tokens, grid_shape, score_projection)
+
+        if score_projection is None:
+            encoder = getattr(model, "encoder", None)
+            norm = getattr(encoder, "ln", None)
+            heads = getattr(model, "heads", None)
+            if not isinstance(norm, nn.Module) or not isinstance(heads, nn.Module):
+                raise ValueError("`score_projection` is required for models other than torchvision VisionTransformer")
+
+            def project_tokens(tokens: Tensor) -> Tensor:
+                return heads(norm(tokens.mean(dim=1)))
+
+            score_projection = project_tokens
+
+        self._score_projection = score_projection
+        self.prefix_tokens = prefix_tokens
+        self.grid_shape = grid_shape
+        super().__init__(model, target_layer, enable_hooks=enable_hooks)
+
+        try:
+            self._register_attention_hooks()
+        except Exception:
+            self.remove_hooks()
+            raise
+
+    @staticmethod
+    def _validate_init_args(
+        prefix_tokens: int,
+        grid_shape: tuple[int, int] | None,
+        score_projection: Callable[[Tensor], Tensor] | None,
+    ) -> None:
+        if not isinstance(prefix_tokens, int):
+            raise TypeError("`prefix_tokens` must be an integer")
+        if prefix_tokens < 0:
+            raise ValueError("`prefix_tokens` must be non-negative")
+        if grid_shape is not None and (
+            not isinstance(grid_shape, tuple)
+            or len(grid_shape) != 2
+            or any(not isinstance(dim, int) for dim in grid_shape)
+        ):
+            raise TypeError("`grid_shape` must be a tuple of two integers")
+        if grid_shape is not None and any(dim <= 0 for dim in grid_shape):
+            raise ValueError("`grid_shape` dimensions must be positive")
+        if score_projection is not None and not callable(score_projection):
+            raise TypeError("`score_projection` must be callable")
+
+    def _register_attention_hooks(self) -> None:
+        for idx, name in enumerate(self.target_names):
+            attention = getattr(self.submodule_dict[name], "self_attention", None)
+            if not isinstance(attention, nn.MultiheadAttention):
+                raise TypeError(f"target block '{name}' must expose `self_attention: nn.MultiheadAttention`")
+            self._validate_attention(attention, name)
+            self.hook_handles.append(
+                attention.register_forward_pre_hook(partial(self._prepare_attention, idx=idx), with_kwargs=True)
+            )
+            self.hook_handles.append(
+                attention.register_forward_hook(partial(self._capture_attention, idx=idx), with_kwargs=True)
+            )
+
+    @staticmethod
+    def _validate_attention(attention: nn.MultiheadAttention, name: str) -> None:
+        if not attention.batch_first:
+            raise ValueError(f"target block '{name}' requires batch-first attention")
+        if (
+            attention.kdim != attention.embed_dim
+            or attention.vdim != attention.embed_dim
+            or attention.in_proj_weight is None
+        ):
+            raise ValueError(f"target block '{name}' requires shared-dimension Q/K/V projections")
+        if attention.bias_k is not None or attention.bias_v is not None or attention.add_zero_attn:
+            raise ValueError(f"target block '{name}' does not support added attention tokens")
+
+    def reset_hooks(self) -> None:
+        """Clear stored layer scores and attention probabilities."""
+        super().reset_hooks()
+        self.hook_attn: list[Tensor | None] = [None] * len(self.target_names)
+        self._token_counts: list[int | None] = [None] * len(self.target_names)
+        self._weight_options: list[tuple[bool, bool] | None] = [None] * len(self.target_names)
+
+    def _prepare_attention(
+        self,
+        module: nn.MultiheadAttention,
+        input_: tuple[Any, ...],
+        kwargs: dict[str, Any],
+        idx: int = 0,
+    ) -> tuple[tuple[Any, ...], dict[str, Any]] | None:
+        if not self._hooks_enabled:
+            return None
+        if not torch.is_grad_enabled() or torch.is_inference_mode_enabled():
+            raise RuntimeError("LeGrad requires a forward pass with gradient tracking enabled")
+        if module.training and module.dropout > 0:
+            raise ValueError("LeGrad does not support active attention dropout")
+        if len(input_) < 3 or any(not isinstance(arg, Tensor) for arg in input_[:3]):
+            raise ValueError("LeGrad requires tensor query, key, and value inputs")
+
+        query, key, value = input_[:3]
+        if query is not key or query is not value:
+            raise ValueError("LeGrad only supports self-attention")
+        if query.ndim != 3:
+            raise ValueError("LeGrad requires attention inputs shaped (batch, tokens, embedding)")
+
+        args = list(input_)
+        in_proj_bias = module.in_proj_bias
+        if not (
+            query.requires_grad
+            or module.in_proj_weight.requires_grad
+            or (in_proj_bias is not None and in_proj_bias.requires_grad)
+        ):
+            # Keep parameter flags untouched while making attention differentiable.
+            query = query.detach().requires_grad_()
+            args[:3] = [query, query, query]
+
+        # These positions follow nn.MultiheadAttention.forward; tests cover positional calls.
+        requested = args[4] if len(args) > 4 else kwargs.get("need_weights", True)
+        averaged = args[6] if len(args) > 6 else kwargs.get("average_attn_weights", True)
+        self._weight_options[idx] = (bool(requested), bool(averaged))
+
+        kwargs = dict(kwargs)
+        if len(args) > 4:
+            args[4] = True
+        else:
+            kwargs["need_weights"] = True
+        if len(args) > 6:
+            args[6] = False
+        else:
+            kwargs["average_attn_weights"] = False
+        return tuple(args), kwargs
+
+    def _capture_attention(
+        self,
+        module: nn.MultiheadAttention,
+        input_: tuple[Any, ...],
+        _kwargs: dict[str, Any],
+        output: tuple[Tensor, Tensor | None],
+        idx: int = 0,
+    ) -> tuple[Tensor, Tensor | None] | None:
+        if not self._hooks_enabled:
+            return None
+        if not isinstance(output, tuple) or len(output) != 2 or not isinstance(output[1], Tensor):
+            raise ValueError("LeGrad requires per-head attention probabilities from `nn.MultiheadAttention`")
+
+        attention = output[1]
+        value = input_[2]
+        if not isinstance(value, Tensor) or attention.ndim != 4:
+            raise ValueError("LeGrad requires attention probabilities shaped (batch, heads, queries, keys)")
+
+        batch_size, source_length, _ = value.shape
+        if (
+            attention.shape[0] != batch_size
+            or attention.shape[1] != module.num_heads
+            or attention.shape[-1] != source_length
+        ):
+            raise ValueError("incompatible attention probability shape")
+
+        # Replay aggregation so the captured post-softmax tensor is downstream-used.
+        embed_dim = module.embed_dim
+        value = F.linear(
+            value,
+            module.in_proj_weight[2 * embed_dim :],
+            None if module.in_proj_bias is None else module.in_proj_bias[2 * embed_dim :],
+        )
+        value = value.reshape(batch_size, source_length, module.num_heads, embed_dim // module.num_heads)
+        value = value.transpose(1, 2)
+        attention_output = torch.matmul(attention, value).transpose(1, 2)
+        attention_output = attention_output.reshape(batch_size, attention.shape[-2], embed_dim)
+        attention_output = module.out_proj(attention_output)
+        self.hook_attn[idx] = attention
+
+        options = self._weight_options[idx]
+        if options is None:
+            raise RuntimeError("missing original attention return options")
+        requested, averaged = options
+        returned_attention = attention.mean(dim=1) if requested and averaged else attention if requested else None
+        return attention_output, returned_attention
+
+    def _hook_a(self, _: nn.Module, _input: tuple[Tensor, ...], output: Tensor, idx: int = 0) -> None:
+        if not self._hooks_enabled:
+            return
+        if not isinstance(output, Tensor) or output.ndim != 3:
+            raise ValueError("LeGrad target blocks must return tokens shaped (batch, tokens, embedding)")
+        # Reuse inherited activation slots for layer-specific logits.
+        scores = self._score_projection(output)
+        if not isinstance(scores, Tensor) or scores.ndim != 2 or scores.shape[0] != output.shape[0]:
+            raise ValueError("`score_projection` must return class logits shaped (batch, classes)")
+        self.hook_a[idx] = scores
+        self._token_counts[idx] = output.shape[1]
+
+    def _precheck(self, class_idx: int | list[int], scores: Tensor | None = None) -> None:
+        super()._precheck(class_idx, scores)
+        if any(not isinstance(attention, Tensor) for attention in self.hook_attn):
+            raise AssertionError("Inputs need to be forwarded through every LeGrad target block")
+
+    def _get_weights(
+        self,
+        class_idx: int | list[int],
+        _scores: Tensor | None = None,
+        retain_graph: bool = False,
+        **_: Any,
+    ) -> list[Tensor]:
+        relevances: list[Tensor] = []
+        for idx, (scores, attention) in enumerate(zip(self.hook_a, self.hook_attn, strict=True)):
+            if not isinstance(scores, Tensor) or not isinstance(attention, Tensor):
+                raise AssertionError("Inputs need to be forwarded through every LeGrad target block")  # noqa: TRY004
+            selected = (
+                scores[:, class_idx]
+                if isinstance(class_idx, int)
+                else scores.gather(1, torch.tensor(class_idx, device=scores.device).view(-1, 1)).squeeze(1)
+            )
+            try:
+                grad = torch.autograd.grad(
+                    selected.sum(),
+                    attention,
+                    retain_graph=retain_graph or idx < len(self.target_names) - 1,
+                )[0]
+            except RuntimeError as exc:
+                raise RuntimeError(
+                    f"layer-specific score for '{self.target_names[idx]}' is not connected to its attention"
+                ) from exc
+            relevances.append(grad.relu().mean(dim=(1, 2))[:, self.prefix_tokens :])
+        return relevances
+
+    def _resolve_grid_shape(self, patch_count: int) -> tuple[int, int]:
+        if patch_count <= 0:
+            raise ValueError("`prefix_tokens` must leave at least one patch token")
+        if self.grid_shape is not None:
+            if self.grid_shape[0] * self.grid_shape[1] != patch_count:
+                raise ValueError("`grid_shape` does not match the number of patch tokens")
+            return self.grid_shape
+        side = isqrt(patch_count)
+        if side * side != patch_count:
+            raise ValueError("unable to infer a square patch grid; specify `grid_shape`")
+        return side, side
+
+    def compute_cams(
+        self,
+        class_idx: int | list[int],
+        scores: Tensor | None = None,
+        normalized: bool = True,
+        retain_graph: bool = False,
+        **kwargs: Any,
+    ) -> list[Tensor]:
+        """Compute and average layerwise positive attention-gradient maps.
+
+        Raises:
+            ValueError: if attention and token shapes are incompatible
+        """  # noqa: DOC201
+        relevances = self._get_weights(class_idx, scores, retain_graph=retain_graph, **kwargs)
+        maps: list[Tensor] = []
+        for idx, relevance in enumerate(relevances):
+            token_count = self._token_counts[idx]
+            if token_count is None or token_count != relevance.shape[-1] + self.prefix_tokens:
+                raise ValueError("attention keys and target-block tokens must have matching lengths")
+            height, width = self._resolve_grid_shape(relevance.shape[-1])
+            maps.append(relevance.reshape(relevance.shape[0], height, width))
+
+        with torch.no_grad():
+            cam = torch.stack(maps).mean(dim=0)
+            return [self._normalize(cam) if normalized else cam]
 
 
 class RefineCAM(_CAMWrapper):


### PR DESCRIPTION
## Summary

- add a focused `LeGrad` extractor for torchvision `VisionTransformer` encoder blocks and matching batch-first self-attention blocks
- compute layer-specific positive attention gradients, fuse selected layers, and normalize once
- document the exact model boundary, projection callback, prefix/grid behavior, and differences from other transformer explanations

LeGrad follows [the paper](https://arxiv.org/abs/2404.03214): for every selected layer, differentiate that layer's projected class score with respect to its post-softmax attention probabilities, apply ReLU, average heads and queries, remove prefix keys, reshape patches, then average layers. Attention values are never multiplied into the relevance.

## Supported contract

| Model/layout | Status | Requirement |
| --- | --- | --- |
| torchvision `VisionTransformer` | supported | target complete encoder blocks; default projection is token mean -> `encoder.ln` -> `heads` |
| matching custom transformer block | supported with callback | block returns `(N, tokens, dim)`, has direct batch-first `self_attention: nn.MultiheadAttention`, and receives `score_projection(tokens) -> (N, classes)` |
| non-square patch grid | supported | pass `grid_shape=(height, width)` |
| Swin, timm, OpenCLIP, attentional poolers | unsupported | outside this focused contract |
| cross-attention, non-batch-first MHA, separate Q/K/V dimensions | rejected | incompatible attention layout |
| bias/zero-added attention tokens, active attention dropout | rejected | captured tensor would not meet the exact aggregation contract |

## Graph connectivity and restoration

- An MHA pre-hook requests unaveraged per-head weights and creates a temporary grad-enabled attention input only when the existing graph has no gradient path.
- An MHA forward hook recomputes only `attention @ V` plus the existing output projection. The captured post-softmax tensor is therefore the tensor used downstream for the class score while preserving the original numerical output and `need_weights` behavior.
- The deterministic oracle checks captured weights against manual QK-softmax, checks a non-`None` class-score gradient, and checks adapted versus unadapted model outputs.
- Every adapter is a removable hook stored in the inherited lifecycle collection. Tests cover direct removal plus normal and exceptional context exit.
- Forward methods, training flags, parameter gradients, and parameter `requires_grad` values remain unchanged, including frozen and mixed-flag models.

Unlike the [official wrapper](https://github.com/WalBouss/LeGrad/blob/main/legrad/wrapper.py), this implementation does not monkeypatch forward methods or mutate parameter flags.

## Validation

```text
git diff --check
PASS

UV_PYTHON=3.12 uv run --extra test pytest tests/test_methods_transformer.py -q
27 passed in 1.44s

UV_PYTHON=3.12 make test
122 passed

UV_PYTHON=3.12 make quality
Ruff check/format, ty, and dependency synchronization passed

DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/opt/cairo/lib:/opt/homebrew/lib \
  UV_PYTHON=3.12 uv run --extra docs mkdocs build --strict --config-file docs/mkdocs.yml
PASS; documentation built in 1.67s
```

GitHub CI passes on `0e23dd8`, including the cross-platform install/build matrix, tests, code quality, CodeFactor
(`No issues found`), and both Codecov project and patch gates.

The pretrained visual check used the repository Border Collie image, class 232, and the last four ViT-B/16 encoder blocks:

```bash
UV_PYTHON=3.12 uv run --extra test python - <<'PY'
from io import BytesIO
from pathlib import Path

import requests
from PIL import Image
from torchvision.models import ViT_B_16_Weights, vit_b_16
from torchvision.transforms.functional import to_pil_image

from torchcam.methods import LeGrad
from torchcam.utils import overlay_mask

url = "https://www.woopets.fr/assets/races/000/066/big-portrait/border-collie.jpg"
output = Path("/tmp/torchcam-legrad-vit-b-16-class-232.png")
response = requests.get(url, timeout=30)
response.raise_for_status()
image = Image.open(BytesIO(response.content)).convert("RGB")
weights = ViT_B_16_Weights.DEFAULT
model = vit_b_16(weights=weights).eval()
input_tensor = weights.transforms()(image).unsqueeze(0)
target_layers = list(model.encoder.layers)[-4:]

with LeGrad(model, target_layers, prefix_tokens=1) as extractor:
    scores = model(input_tensor)
    cam = extractor(232, scores)[0]

overlay_mask(image, to_pil_image(cam[0], mode="F"), alpha=0.5).save(output)
print(scores.argmax(dim=1).item(), target_layers, output)
PY
```

Result: prediction `232` (`Border collie`); layers `encoder_layer_8` through `encoder_layer_11`; CAM `(1, 14, 14)`, range `0.000000..0.999993`; artifact `/tmp/torchcam-legrad-vit-b-16-class-232.png` (278,223 bytes). Visual inspection showed finite, localized activation over the dog's head and body.
