### PR TITLE
feat(methods): add FinerCAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ This project is developed and maintained by the repo owner, but the implementati
 - [IS-CAM](https://arxiv.org/abs/2010.03023): integration-based variant of Score-CAM.
 - [XGrad-CAM](https://arxiv.org/abs/2008.02312): improved version of Grad-CAM in terms of sensitivity and conservation.
 - [Layer-CAM](http://mftp.mmcheng.net/Papers/21TIP_LayerCAM.pdf): Grad-CAM alternative leveraging pixel-wise contribution of the gradient to the activation.
+- [Finer-CAM](https://arxiv.org/abs/2501.11309): contrastive CAM objective highlighting differences between similar classes.
 - [RefineCAM](https://arxiv.org/abs/2605.14641): multi-layer refinement producing high-resolution activation maps.
 
 *Not sure which one to use? See [Choosing a CAM method](https://frgfm.github.io/torch-cam/getting-started/advanced-usage/#choosing-a-cam-method).*

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -167,6 +167,7 @@ pip install "torchcam @ git+https://github.com/frgfm/torch-cam.git"
 - [IS-CAM](https://arxiv.org/abs/2010.03023)：Score-CAM 的积分变体。
 - [XGrad-CAM](https://arxiv.org/abs/2008.02312)：在敏感性和守恒性方面改进的 Grad-CAM。
 - [Layer-CAM](http://mftp.mmcheng.net/Papers/21TIP_LayerCAM.pdf)：Grad-CAM 的替代方案，利用梯度对激活的逐像素贡献。
+- [Finer-CAM](https://arxiv.org/abs/2501.11309)：通过对比相似类别突出细粒度差异的 CAM 目标。
 - [RefineCAM](https://arxiv.org/abs/2605.14641)：融合多个网络层以生成高分辨率类激活图。
 
 *不知道该用哪一种？请参阅[如何选择 CAM 方法](https://frgfm.github.io/torch-cam/getting-started/advanced-usage/#choosing-a-cam-method)。*

--- a/docs/docs/getting-started/advanced-usage.md
+++ b/docs/docs/getting-started/advanced-usage.md
@@ -97,6 +97,31 @@ with RefineCAM(model, ["layer2", "layer3", "layer4"], base_method=LayerCAM) as c
     refined = cam_extractor(out.squeeze(0).argmax().item(), out)[0]
 ```
 
+`FinerCAM` instead changes **what** a gradient method explains. For target class $c$ and reference classes $d_t$,
+it replaces the target score with the contrastive objective
+
+$$
+y_c - \gamma \frac{1}{T} \sum\limits_{t=1}^{T} y_{d_t}.
+$$
+
+The references are averaged before the base method's final CAM ReLU. By default, `gamma=0.6` and up to three
+classes whose logits are closest to the target logit are selected automatically, excluding the target. Pass an
+integer or flat list to share explicit references across the batch, or an equal-width nested list with one row per
+sample. Explicit references override `num_references`.
+
+```python
+from torchcam.methods import FinerCAM, LayerCAM
+
+with FinerCAM(model, "layer4", base_method=LayerCAM) as cam_extractor:
+    out = model(input_tensor)
+    class_idx = out.squeeze(0).argmax().item()
+    cams = cam_extractor(class_idx, out, comparison_idx=[12, 37, 84])
+```
+
+`FinerCAM` supports `GradCAM`, `GradCAMpp`, and `LayerCAM`, requires the original differentiable score tensor, and
+returns one tensor per selected layer. Its intended behavior is improved discrimination between fine-grained
+classes; it is not a universal guarantee of better localization. Score-based CAM methods are not approximated.
+
 ## Understanding `class_idx` and the call signature
 
 ```python
@@ -255,6 +280,7 @@ extra spatial dimension). Note that `overlay_mask` works on 2D PIL images, so ov
 | `CAM`                       | no              | cheapest                 | needs global pooling + a **single** `nn.Linear` head (e.g. ResNet); fails on multi-FC heads like VGG |
 | `GradCAM`                   | yes             | one backward pass        | robust default for most CNNs |
 | `LayerCAM`                  | yes             | one backward pass        | best localization in our benchmark; ideal when fusing layers |
+| `FinerCAM`                  | yes             | one backward pass        | contrastive fine-grained cues with `GradCAM`, `GradCAMpp`, or `LayerCAM` |
 | `RefineCAM`                 | depends on base | base method + cheap fusion | high-resolution fusion across at least two layers; defaults to `GradCAMpp` |
 | `GradCAMpp` / `XGradCAM`    | yes             | one backward pass        | alternative weighting schemes |
 | `SmoothGradCAMpp`           | yes             | `num_samples` forwards   | sharper maps via noise averaging |

--- a/docs/docs/reference/methods.md
+++ b/docs/docs/reference/methods.md
@@ -41,6 +41,7 @@ Methods related to gradient-based class activation maps.
         show_root_heading: false
         show_root_toc_entry: false
         members:
+            - FinerCAM
             - GradCAM
             - GradCAMpp
             - SmoothGradCAMpp

--- a/tests/test_methods_gradient.py
+++ b/tests/test_methods_gradient.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from functools import partial
 
 import pytest
@@ -16,7 +17,7 @@ def _verify_cam(activation_map, output_size):
     assert not torch.isnan(activation_map).any()
 
 
-def _tiny_model():
+def _tiny_model(num_classes=3):
     return nn.Sequential(
         nn.Conv2d(3, 4, 3, padding=1),
         nn.ReLU(),
@@ -24,8 +25,20 @@ def _tiny_model():
         nn.ReLU(),
         nn.AdaptiveAvgPool2d((1, 1)),
         nn.Flatten(1),
-        nn.Linear(4, 3),
+        nn.Linear(4, num_classes),
     ).eval()
+
+
+def _contrastive_scores(scores, class_idx, comparison_idx, gamma):
+    batch_size = scores.shape[0]
+    targets = [class_idx] * batch_size if isinstance(class_idx, int) else class_idx
+    if isinstance(comparison_idx, int):
+        references = [[comparison_idx]] * batch_size
+    else:
+        references = [comparison_idx] * batch_size if isinstance(comparison_idx[0], int) else comparison_idx
+    target_indices = torch.tensor(targets, device=scores.device).view(-1, 1)
+    reference_indices = torch.tensor(references, device=scores.device)
+    return scores.gather(1, target_indices) - gamma * scores.gather(1, reference_indices).mean(1, keepdim=True)
 
 
 @pytest.mark.parametrize(
@@ -196,6 +209,281 @@ def test_refinecam_rejects_invalid_configuration():
         gradient.RefineCAM(model, ["0"])
     with pytest.raises(TypeError, match="CAM extractor class"):
         gradient.RefineCAM(model, ["0", "2"], base_method=nn.Module)
+
+
+@pytest.mark.parametrize("base_method", [gradient.GradCAM, gradient.GradCAMpp, gradient.LayerCAM])
+@pytest.mark.parametrize(
+    ("class_idx", "comparison_idx"),
+    [(0, 2), ([0, 1], [2]), ([0, 1], [[1, 2], [0, 2]])],
+)
+@pytest.mark.parametrize("normalized", [False, True])
+def test_finercam_matches_manual_contrastive_score(base_method, class_idx, comparison_idx, normalized):
+    model = _tiny_model()
+    manual_model = deepcopy(model)
+    input_tensor = torch.rand((2, 3, 8, 8))
+    gamma = 0.6
+
+    with gradient.FinerCAM(model, "2", base_method=base_method, gamma=gamma) as extractor:
+        scores = model(input_tensor)
+        original_scores = scores.detach().clone()
+        cams = extractor(class_idx, scores, comparison_idx, normalized)
+
+    with base_method(manual_model, "2") as base_cam:
+        manual_scores = manual_model(input_tensor)
+        contrastive_scores = _contrastive_scores(manual_scores, class_idx, comparison_idx, gamma)
+        expected = base_cam([0, 0], contrastive_scores, normalized)
+
+    assert len(cams) == len(expected) == 1
+    torch.testing.assert_close(cams[0], expected[0])
+    assert torch.equal(scores.detach(), original_scores)
+    assert scores.shape == (2, 3)
+
+
+def test_finercam_automatic_references_cap_and_use_closest_scores(monkeypatch):
+    model = _tiny_model(num_classes=3)
+    input_tensor = torch.rand((2, 3, 8, 8))
+
+    with gradient.FinerCAM(model, "2", num_references=10) as extractor:
+        scores = model(input_tensor)
+        class_idx = [1, 2]
+        target_indices = torch.tensor(class_idx).view(-1, 1)
+        distances = (scores.detach() - scores.detach().gather(1, target_indices)).abs()
+        distances.scatter_(1, target_indices, float("inf"))
+        references = distances.topk(2, dim=1, largest=False).indices
+        expected = scores.gather(1, target_indices) - 0.6 * scores.gather(1, references).mean(1, keepdim=True)
+        calls = []
+        backprop = extractor.base_cam._backprop
+
+        def capture_backprop(contrastive_scores, objective_idx, **kwargs):
+            calls.append((contrastive_scores, objective_idx))
+            return backprop(contrastive_scores, objective_idx, **kwargs)
+
+        monkeypatch.setattr(extractor.base_cam, "_backprop", capture_backprop)
+        extractor(class_idx, scores)
+
+    assert len(calls) == 1
+    torch.testing.assert_close(calls[0][0], expected)
+    assert calls[0][1] == [0, 0]
+
+
+@pytest.mark.parametrize("num_classes", [2, 3])
+def test_finercam_caps_automatic_references_for_small_outputs(num_classes):
+    model = _tiny_model(num_classes)
+    input_tensor = torch.rand((1, 3, 8, 8))
+
+    with gradient.FinerCAM(model, "2") as extractor:
+        scores = model(input_tensor)
+        cams = extractor(0, scores, normalized=False)
+
+    _verify_cam(cams[0], (1, 8, 8))
+
+
+def test_finercam_gamma_zero_matches_base_cam():
+    model = _tiny_model()
+    manual_model = deepcopy(model)
+    input_tensor = torch.rand((2, 3, 8, 8))
+    class_idx = [0, 1]
+
+    with gradient.FinerCAM(model, "2", gamma=0) as extractor:
+        scores = model(input_tensor)
+        cams = extractor(class_idx, scores, normalized=False)
+
+    with gradient.GradCAM(manual_model, "2") as base_cam:
+        scores = manual_model(input_tensor)
+        expected = base_cam(class_idx, scores, normalized=False)
+
+    torch.testing.assert_close(cams[0], expected[0])
+
+
+def test_finercam_aggregates_before_relu():
+    class ContrastiveModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.features = nn.Conv2d(1, 1, 1, bias=False)
+            self.pool = nn.AdaptiveAvgPool2d((1, 1))
+            self.classifier = nn.Linear(1, 3, bias=False)
+            with torch.no_grad():
+                self.features.weight.fill_(1)
+                self.classifier.weight.copy_(torch.tensor([[1.0], [3.0], [-1.0]]))
+
+        def forward(self, input_tensor):
+            return self.classifier(self.pool(self.features(input_tensor)).flatten(1))
+
+    model = ContrastiveModel().eval()
+    input_tensor = torch.ones((1, 1, 2, 2))
+
+    with gradient.FinerCAM(model, "features", gamma=1) as extractor:
+        scores = model(input_tensor)
+        aggregated = extractor(0, scores, [1, 2], normalized=False)[0]
+
+    pairwise_cams = []
+    for reference in [1, 2]:
+        pair_model = deepcopy(model)
+        with gradient.GradCAM(pair_model, "features") as extractor:
+            scores = pair_model(input_tensor)
+            contrastive_scores = _contrastive_scores(scores, 0, [reference], 1)
+            pairwise_cams.append(extractor(0, contrastive_scores, normalized=False)[0])
+
+    assert torch.count_nonzero(aggregated) == 0
+    assert torch.stack(pairwise_cams).mean(0).max() > 0
+
+
+def test_finercam_multiple_layers_and_compute_cams():
+    model = nn.Sequential(
+        nn.Conv2d(3, 4, 3, padding=1),
+        nn.ReLU(),
+        nn.Conv2d(4, 4, 3, stride=2, padding=1),
+        nn.ReLU(),
+        nn.AdaptiveAvgPool2d((1, 1)),
+        nn.Flatten(1),
+        nn.Linear(4, 3),
+    ).eval()
+    input_tensor = torch.rand((1, 3, 8, 8))
+
+    with gradient.FinerCAM(model, ["0", "2"]) as extractor:
+        scores = model(input_tensor)
+        cams = extractor.compute_cams(0, scores, [1, 2], normalized=False)
+
+    assert [cam.shape for cam in cams] == [(1, 8, 8), (1, 4, 4)]
+
+
+def test_finercam_video_cam(mock_video_tensor):
+    model = nn.Sequential(
+        nn.Conv3d(3, 4, 3, padding=1),
+        nn.ReLU(),
+        nn.AdaptiveAvgPool3d((1, 1, 1)),
+        nn.Flatten(1),
+        nn.Linear(4, 3),
+    ).eval()
+
+    with gradient.FinerCAM(model, "0", base_method=gradient.LayerCAM) as extractor:
+        scores = model(mock_video_tensor)
+        cams = extractor(0, scores, comparison_idx=[1, 2])
+
+    _verify_cam(cams[0], (1, 8, 16, 16))
+
+
+@pytest.mark.parametrize(
+    "device",
+    [
+        torch.device("cpu"),
+        pytest.param(torch.device("cuda"), marks=pytest.mark.skipif(not torch.cuda.is_available(), reason="no CUDA")),
+    ],
+)
+def test_finercam_preserves_dtype_and_device(device):
+    model = _tiny_model().to(device=device, dtype=torch.float64)
+    input_tensor = torch.rand((1, 3, 8, 8), device=device, dtype=torch.float64)
+
+    with gradient.FinerCAM(model, "2") as extractor:
+        scores = model(input_tensor)
+        cams = extractor(0, scores, comparison_idx=[1, 2], normalized=False)
+
+    assert cams[0].dtype == scores.dtype == torch.float64
+    assert cams[0].device == scores.device == device
+
+
+def test_finercam_lifecycle_repr_and_metric_compatibility():
+    model = _tiny_model()
+    input_tensor = torch.rand((1, 3, 8, 8))
+    target_layer = model[2]
+    assert len(target_layer._forward_hooks) == 0
+
+    with gradient.FinerCAM(model, "2") as extractor:
+        assert len(target_layer._forward_hooks) == 2
+        assert extractor.model is model
+        assert extractor.target_names == ["2"]
+        assert repr(extractor) == ("FinerCAM(base_method=GradCAM, target_layer=['2'], gamma=0.6, num_references=3)")
+        metric = ClassificationMetric(extractor, partial(torch.softmax, dim=-1))
+        metric.update(input_tensor)
+        assert set(metric.summary()) == {"avg_drop", "conf_increase"}
+
+    assert len(target_layer._forward_hooks) == 0
+    assert extractor.base_cam.hook_handles == []
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "error", "match"),
+    [
+        ({"base_method": activation.ScoreCAM}, TypeError, "GradCAM, GradCAMpp, or LayerCAM"),
+        ({"base_method": gradient.SmoothGradCAMpp}, TypeError, "GradCAM, GradCAMpp, or LayerCAM"),
+        ({"base_method": nn.Identity()}, TypeError, "GradCAM, GradCAMpp, or LayerCAM"),
+        ({"gamma": True}, TypeError, "real number"),
+        ({"gamma": "0.6"}, TypeError, "real number"),
+        ({"gamma": -0.1}, ValueError, "finite and non-negative"),
+        ({"gamma": float("inf")}, ValueError, "finite and non-negative"),
+        ({"gamma": float("nan")}, ValueError, "finite and non-negative"),
+        ({"num_references": True}, TypeError, "integer"),
+        ({"num_references": 1.5}, TypeError, "integer"),
+        ({"num_references": 0}, ValueError, "positive"),
+    ],
+)
+def test_finercam_rejects_invalid_configuration(kwargs, error, match):
+    with pytest.raises(error, match=match):
+        gradient.FinerCAM(_tiny_model(), "2", **kwargs)
+
+
+def test_finercam_rejects_invalid_scores_targets_and_references():
+    model = _tiny_model()
+    input_tensor = torch.rand((2, 3, 8, 8))
+
+    with gradient.FinerCAM(model, "2") as extractor:
+        with pytest.raises(ValueError, match="scores is required"):
+            extractor(0)
+        with pytest.raises(TypeError, match="scores must be a tensor"):
+            extractor(0, [[1.0, 2.0]])
+        with pytest.raises(ValueError, match="shape"):
+            extractor(0, torch.rand(3))
+        with pytest.raises(ValueError, match="comparison class"):
+            extractor(0, torch.rand((2, 1)))
+
+        scores = model(input_tensor)
+        with pytest.raises(TypeError, match="class_idx"):
+            extractor(True, scores)
+        with pytest.raises(TypeError, match="contain integers"):
+            extractor([0, True], scores)
+        with pytest.raises(ValueError, match="batch size"):
+            extractor([0], scores)
+        with pytest.raises(ValueError, match="out-of-range"):
+            extractor([0, 3], scores)
+        with pytest.raises(ValueError, match="cannot be empty"):
+            extractor([0, 1], scores, [])
+        with pytest.raises(TypeError, match="integer, a list, or a nested list"):
+            extractor([0, 1], scores, (2,))
+        with pytest.raises(ValueError, match="target class"):
+            extractor([0, 1], scores, [0, 2])
+        with pytest.raises(ValueError, match="duplicates"):
+            extractor([0, 1], scores, [2, 2])
+        with pytest.raises(ValueError, match="out-of-range"):
+            extractor([0, 1], scores, [2, 3])
+        with pytest.raises(TypeError, match="contain integers"):
+            extractor([0, 1], scores, [True])
+        with pytest.raises(ValueError, match="batch size"):
+            extractor([0, 1], scores, [[1, 2]])
+        with pytest.raises(ValueError, match="rows cannot be empty"):
+            extractor([0, 1], scores, [[], []])
+        with pytest.raises(ValueError, match="equal lengths"):
+            extractor([0, 1], scores, [[1], [0, 2]])
+        with pytest.raises(TypeError, match="contain integers"):
+            extractor([0, 1], scores, [[True], [0]])
+        with pytest.raises(TypeError, match="integers or lists"):
+            extractor([0, 1], scores, [2, [0]])
+
+
+def test_refinecam_shared_wrapper_regression():
+    model = _tiny_model()
+    input_tensor = torch.rand((1, 3, 8, 8))
+    extractor = gradient.RefineCAM(model, ["0", "2"])
+
+    with extractor as entered:
+        assert entered is extractor
+        extractor.disable_hooks()
+        assert not extractor.base_cam._hooks_enabled
+        extractor.enable_hooks()
+        scores = model(input_tensor)
+        _verify_cam(extractor(0, scores)[0], (1, 8, 8))
+        assert repr(extractor) == "RefineCAM(base_method=GradCAMpp, target_layer=['0', '2'])"
+
+    assert extractor.base_cam.hook_handles == []
 
 
 def test_gradcam_does_not_accumulate_hook_handles(mock_img_tensor):

--- a/torchcam/methods/gradient.py
+++ b/torchcam/methods/gradient.py
@@ -5,8 +5,9 @@
 
 from contextlib import AbstractContextManager
 from functools import partial
+from math import isfinite
 from types import TracebackType
-from typing import Any, Self
+from typing import Any, Self, cast
 
 import torch
 from torch import Tensor, nn
@@ -14,7 +15,7 @@ from torch.nn import functional as F
 
 from .core import _CAM
 
-__all__ = ["GradCAM", "GradCAMpp", "LayerCAM", "RefineCAM", "SmoothGradCAMpp", "XGradCAM"]
+__all__ = ["FinerCAM", "GradCAM", "GradCAMpp", "LayerCAM", "RefineCAM", "SmoothGradCAMpp", "XGradCAM"]
 
 
 class _GradCAM(_CAM):
@@ -458,7 +459,55 @@ class LayerCAM(_GradCAM):
         return [torch.tanh(gamma * cam) for cam in cams]
 
 
-class RefineCAM:
+class _CAMWrapper:
+    """Delegate CAM extractor metadata and lifecycle without duplicating hooks."""
+
+    def __init__(self, base_cam: _CAM) -> None:
+        self.base_cam = base_cam
+
+    @property
+    def model(self) -> nn.Module:
+        """The model wrapped by the base extractor."""
+        return self.base_cam.model
+
+    @property
+    def target_names(self) -> list[str]:
+        """The target layer names used by the base extractor."""
+        return self.base_cam.target_names
+
+    def enable_hooks(self) -> None:
+        """Enable the base extractor hooks."""
+        self.base_cam.enable_hooks()
+
+    def disable_hooks(self) -> None:
+        """Disable the base extractor hooks."""
+        self.base_cam.disable_hooks()
+
+    def reset_hooks(self) -> None:
+        """Clear the activations and gradients stored by the base extractor."""
+        self.base_cam.reset_hooks()
+
+    def remove_hooks(self) -> None:
+        """Remove the base extractor hooks from the model."""
+        self.base_cam.remove_hooks()
+
+    def _hooks_off(self) -> AbstractContextManager[None]:
+        return self.base_cam._hooks_off()  # noqa: SLF001
+
+    def __enter__(self) -> Self:
+        self.base_cam.__enter__()
+        return self
+
+    def __exit__(
+        self,
+        exct_type: type[BaseException] | None,
+        exce_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self.base_cam.__exit__(exct_type, exce_value, traceback)
+
+
+class RefineCAM(_CAMWrapper):
     r"""Implements the multi-layer refinement described in ["How to Evaluate and Refine your CAM"](
     https://arxiv.org/abs/2605.14641).
 
@@ -498,49 +547,7 @@ class RefineCAM:
         if not isinstance(base_method, type) or not issubclass(base_method, _CAM):
             raise TypeError("base_method must be a CAM extractor class")
 
-        self.base_cam = base_method(model, target_layer, input_shape=input_shape, **base_kwargs)
-
-    @property
-    def model(self) -> nn.Module:
-        """The model wrapped by the base extractor."""
-        return self.base_cam.model
-
-    @property
-    def target_names(self) -> list[str]:
-        """The target layer names used by the base extractor."""
-        return self.base_cam.target_names
-
-    def enable_hooks(self) -> None:
-        """Enable the base extractor hooks."""
-        self.base_cam.enable_hooks()
-
-    def disable_hooks(self) -> None:
-        """Disable the base extractor hooks."""
-        self.base_cam.disable_hooks()
-
-    def reset_hooks(self) -> None:
-        """Clear the activations and gradients stored by the base extractor."""
-        self.base_cam.reset_hooks()
-
-    def remove_hooks(self) -> None:
-        """Remove the base extractor hooks from the model."""
-        self.base_cam.remove_hooks()
-
-    def _hooks_off(self) -> AbstractContextManager[None]:
-        return self.base_cam._hooks_off()  # noqa: SLF001
-
-    def __enter__(self) -> Self:
-        """Return the RefineCAM context manager."""  # noqa: DOC201
-        return self
-
-    def __exit__(
-        self,
-        exct_type: type[BaseException] | None,
-        exce_value: BaseException | None,
-        traceback: TracebackType | None,
-    ) -> None:
-        """Remove and reset the base extractor hooks."""
-        self.base_cam.__exit__(exct_type, exce_value, traceback)
+        super().__init__(base_method(model, target_layer, input_shape=input_shape, **base_kwargs))
 
     def __call__(
         self,
@@ -602,3 +609,185 @@ class RefineCAM:
     def __repr__(self) -> str:
         """Return the RefineCAM representation."""  # noqa: DOC201
         return f"RefineCAM(base_method={self.base_cam.__class__.__name__}, target_layer={self.target_names})"
+
+
+class FinerCAM(_CAMWrapper):
+    r"""Implements ["Finer-CAM: Spotting the Difference Reveals Finer Details for Visual Explanation"](
+    https://arxiv.org/abs/2501.11309).
+
+    Finer-CAM changes the base extractor objective from the target score $y_c$ to the contrastive objective
+
+    $$
+    y_c - \gamma \frac{1}{T} \sum\limits_{t=1}^{T} y_{d_t},
+    $$
+
+    so comparisons are aggregated before the base method's final CAM ReLU. Automatic references are the classes
+    with scores closest to the target score. The target is always excluded, and the requested count is capped by the
+    available classes. Only GradCAM, GradCAMpp, and LayerCAM are supported initially.
+
+    Example:
+        ```python
+        from torchvision.models import get_model, get_model_weights
+        from torchcam.methods import FinerCAM, LayerCAM
+        model = get_model("resnet18", weights=get_model_weights("resnet18").DEFAULT).eval()
+        with FinerCAM(model, "layer4", base_method=LayerCAM) as cam_extractor:
+            scores = model(input_tensor)
+            cams = cam_extractor(class_idx=100, scores=scores, comparison_idx=[101, 102, 103])
+        ```
+
+    Args:
+        model: input model
+        target_layer: either the target layer itself or its name, or a list of those
+        input_shape: shape of the expected input tensor excluding the batch dimension
+        base_method: gradient CAM extractor used to produce the maps
+        gamma: comparison strength applied to the mean reference score
+        num_references: number of automatic references to select, capped by the available non-target classes
+        base_kwargs: keyword arguments forwarded to ``base_method``
+    """
+
+    def __init__(
+        self,
+        model: nn.Module,
+        target_layer: nn.Module | str | list[nn.Module | str] | None = None,
+        input_shape: tuple[int, ...] = (3, 224, 224),
+        *,
+        base_method: type[GradCAM] | type[GradCAMpp] | type[LayerCAM] = GradCAM,
+        gamma: float = 0.6,
+        num_references: int = 3,
+        **base_kwargs: Any,
+    ) -> None:
+        if base_method not in {GradCAM, GradCAMpp, LayerCAM}:
+            raise TypeError("base_method must be GradCAM, GradCAMpp, or LayerCAM")
+        if isinstance(gamma, bool) or not isinstance(gamma, int | float):
+            raise TypeError("gamma must be a real number")
+        if not isfinite(gamma) or gamma < 0:
+            raise ValueError("gamma must be finite and non-negative")
+        if isinstance(num_references, bool) or not isinstance(num_references, int):
+            raise TypeError("num_references must be an integer")
+        if num_references < 1:
+            raise ValueError("num_references must be positive")
+
+        self.gamma = float(gamma)
+        self.num_references = num_references
+        super().__init__(base_method(model, target_layer, input_shape=input_shape, **base_kwargs))
+
+    @staticmethod
+    def _target_indices(class_idx: int | list[int], scores: Tensor) -> tuple[list[int], Tensor]:
+        batch_size, num_classes = scores.shape
+        if isinstance(class_idx, int) and not isinstance(class_idx, bool):
+            targets = [class_idx] * batch_size
+        elif isinstance(class_idx, list):
+            if len(class_idx) != batch_size:
+                raise ValueError("expected batch size and length of `class_idx` to be the same")
+            if any(isinstance(idx, bool) or not isinstance(idx, int) for idx in class_idx):
+                raise TypeError("class_idx must contain integers")
+            targets = class_idx
+        else:
+            raise TypeError("class_idx must be an integer or a list of integers")
+        if any(idx < 0 or idx >= num_classes for idx in targets):
+            raise ValueError("class_idx contains an out-of-range index")
+        return targets, torch.tensor(targets, device=scores.device).view(-1, 1)
+
+    @staticmethod
+    def _explicit_reference_rows(comparison_idx: int | list[int] | list[list[int]], batch_size: int) -> list[list[int]]:
+        if isinstance(comparison_idx, int) and not isinstance(comparison_idx, bool):
+            return [[comparison_idx]] * batch_size
+        if not isinstance(comparison_idx, list):
+            raise TypeError("comparison_idx must be an integer, a list, or a nested list")
+        if not comparison_idx:
+            raise ValueError("comparison_idx cannot be empty")
+        if all(isinstance(row, list) for row in comparison_idx):
+            references = cast(list[list[int]], comparison_idx)
+            if len(references) != batch_size:
+                raise ValueError("per-sample comparison_idx must match the batch size")
+            if any(not row for row in references):
+                raise ValueError("comparison_idx rows cannot be empty")
+            if len({len(row) for row in references}) != 1:
+                raise ValueError("per-sample comparison_idx rows must have equal lengths")
+            return references
+        if all(isinstance(idx, int) and not isinstance(idx, bool) for idx in comparison_idx):
+            return [cast(list[int], comparison_idx)] * batch_size
+        raise TypeError("comparison_idx must contain integers or lists of integers")
+
+    def _reference_indices(
+        self,
+        comparison_idx: int | list[int] | list[list[int]] | None,
+        scores: Tensor,
+        targets: list[int],
+        target_indices: Tensor,
+    ) -> Tensor:
+        batch_size, num_classes = scores.shape
+        if comparison_idx is None:
+            reference_count = min(self.num_references, num_classes - 1)
+            distances = (scores.detach() - scores.detach().gather(1, target_indices)).abs()
+            distances.scatter_(1, target_indices, float("inf"))
+            return distances.topk(reference_count, dim=1, largest=False).indices
+
+        references = self._explicit_reference_rows(comparison_idx, batch_size)
+        for sample_idx, (target, row) in enumerate(zip(targets, references, strict=True)):
+            if any(isinstance(idx, bool) or not isinstance(idx, int) for idx in row):
+                raise TypeError("comparison_idx must contain integers")
+            if any(idx < 0 or idx >= num_classes for idx in row):
+                raise ValueError(f"comparison_idx contains an out-of-range index for sample {sample_idx}")
+            if len(set(row)) != len(row):
+                raise ValueError(f"comparison_idx contains duplicates for sample {sample_idx}")
+            if target in row:
+                raise ValueError(f"comparison_idx contains the target class for sample {sample_idx}")
+        return torch.tensor(references, device=scores.device)
+
+    def _contrastive_scores(
+        self,
+        class_idx: int | list[int],
+        scores: Tensor | None,
+        comparison_idx: int | list[int] | list[list[int]] | None,
+    ) -> Tensor:
+        if scores is None:
+            raise ValueError("model output scores is required to compute FinerCAM")
+        if not isinstance(scores, Tensor):
+            raise TypeError("scores must be a tensor")
+        if scores.ndim != 2 or scores.shape[0] < 1:
+            raise ValueError("scores must have shape (batch_size, num_classes)")
+        if scores.shape[1] < 2:
+            raise ValueError("FinerCAM requires at least one comparison class")
+
+        targets, target_indices = self._target_indices(class_idx, scores)
+        reference_indices = self._reference_indices(comparison_idx, scores, targets, target_indices)
+        target_scores = scores.gather(1, target_indices)
+        reference_scores = scores.gather(1, reference_indices).mean(dim=1, keepdim=True)
+        return target_scores - self.gamma * reference_scores
+
+    def __call__(
+        self,
+        class_idx: int | list[int],
+        scores: Tensor | None = None,
+        comparison_idx: int | list[int] | list[list[int]] | None = None,
+        normalized: bool = True,
+        **kwargs: Any,
+    ) -> list[Tensor]:
+        """Compute Finer-CAMs for the target and comparison classes."""  # noqa: DOC201
+        contrastive_scores = self._contrastive_scores(class_idx, scores, comparison_idx)
+        # The contrastive objective is the sole score column, at class index 0.
+        return self.base_cam([0] * contrastive_scores.shape[0], contrastive_scores, normalized, **kwargs)
+
+    def compute_cams(
+        self,
+        class_idx: int | list[int],
+        scores: Tensor | None = None,
+        comparison_idx: int | list[int] | list[list[int]] | None = None,
+        normalized: bool = True,
+        **kwargs: Any,
+    ) -> list[Tensor]:
+        """Compute Finer-CAMs without the base extractor precheck."""  # noqa: DOC201
+        contrastive_scores = self._contrastive_scores(class_idx, scores, comparison_idx)
+        return self.base_cam.compute_cams([0] * contrastive_scores.shape[0], contrastive_scores, normalized, **kwargs)
+
+    def fuse_cams(self, cams: list[Tensor], target_shape: tuple[int, int] | None = None) -> Tensor:
+        """Fuse maps using the selected base extractor."""  # noqa: DOC201
+        return self.base_cam.fuse_cams(cams, target_shape)
+
+    def __repr__(self) -> str:
+        """Return the FinerCAM representation."""  # noqa: DOC201
+        return (
+            f"FinerCAM(base_method={self.base_cam.__class__.__name__}, target_layer={self.target_names}, "
+            f"gamma={self.gamma}, num_references={self.num_references})"
+        )


### PR DESCRIPTION
## Summary

- add paper-faithful Finer-CAM as a composition wrapper over `GradCAM`, `GradCAMpp`, or `LayerCAM`
- preserve one base extractor and one hook set through a small private lifecycle wrapper shared with RefineCAM
- document the contrastive objective, reference selection, supported methods, defaults, and limitations in the API, method chooser, and English/Chinese CAM zoos

## Scientific contract

For sample `i`, target class `c_i`, and `T` reference classes `d_{i,t}`, the implementation constructs

```text
z_i = y_{i,c_i} - gamma * (1 / T) * sum_t y_{i,d_{i,t}}
loss = sum_i z_i
```

and invokes the selected base extractor once. This is the paper aggregation

```text
L^c = ReLU((1 / T) * sum_t sum_k alpha_k^(c,t) A_k)
```

with reference comparisons combined before the base method's final CAM ReLU. Automatic selection may inspect detached values, but `z_i` is gathered from the original score tensor, preserving its graph, device, dtype, batch dimension, and contents.

## API decisions

- defaults: `gamma=0.6`, `num_references=3`, `base_method=GradCAM`
- automatic references: closest scores to the requested target by absolute distance, excluding the target and capped at the available non-target classes
- explicit references: an integer or flat list is shared across the batch; an equal-width nested list supplies one row per sample
- explicit references override `num_references`; duplicates, target references, malformed shapes, and out-of-range indices are rejected
- supported base methods are exactly `GradCAM`, `GradCAMpp`, and `LayerCAM`; score/activation methods and other gradient variants are rejected clearly
- returns TorchCAM's normal `list[Tensor]`, one CAM per selected layer; `base_cam` and base fusion remain accessible

RefineCAM retains its existing constructor, fusion behavior, outputs, hook lifecycle, and representation after moving shared metadata/context delegation to the private wrapper base.

## Deliberate differences from reference implementations

- no softmax probability-weighted reference extension: references are averaged uniformly according to the paper formula
- gradient methods only in this first version, despite the paper describing a separate score-based extension
- no NumPy aggregation or extra output tuple; the wrapper follows TorchCAM's native tensor extractor contract

Finer-CAM is intended to improve discrimination between fine-grained classes, not guarantee universally better localization. No performance claim is added without a reproducible benchmark.

## Validation

Local environment: CPython 3.12. The machine's initial default CPython 3.14t attempt stopped before tests while building NumPy 1.26.4; all reported gates below were rerun successfully with the supported interpreter.

- `uv run --extra test pytest -q tests/test_methods_gradient.py -k "finercam or refinecam"` — **46 passed, 1 skipped** (CUDA unavailable)
- `make test` — **98 passed, 1 skipped**
- `make quality` — **passed** (Ruff lint/format, ty, dependency sync)
- `DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/opt/cairo/lib:/opt/homebrew/lib uv run --extra docs mkdocs build --strict -f docs/mkdocs.yml` — **passed**
- `git diff --check` — **passed**
- `uv run python -c "from torchcam.methods import FinerCAM; print(FinerCAM.__name__)"` — **passed**
- `MPLBACKEND=Agg uv run --extra scripts python scripts/cam_example.py --arch mobilenet_v3_small --method GradCAM,FinerCAM --savefig /tmp/finer-cam-mobilenet-v3-small.png --noblock` — **passed** on the default image; both methods inspected class 157 (`papillon`)

The visualization reuses the existing script and FinerCAM's automatic reference selection; no demo-only API or generated artifact is added to the repository. A simplicity audit likewise found no removable abstraction beyond the required shared wrapper and validation helpers.

## Adversarial review

Independent reviews from OpenCode/Mimo, Claude Sonnet 5, Codex GPT-5.6, and Cursor/Composer found no blocking correctness or scope issue. Follow-up changes narrow the `base_method` annotation to the three supported extractors and document why the one-column contrastive objective is selected at class index 0. Suggested extra bool-validation abstraction, automatic-reference tie documentation, and a broader core fusion annotation were left out as low-value or outside this focused change.
