### PR TITLE
feat(demo): modernize app and automate HF deployment

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -13,7 +13,14 @@ on:
       - '.github/workflows/demo.yml'
       - 'demo/**'
       - 'pyproject.toml'
-  workflow_dispatch:  # Allow manual trigger from Actions tab
+  workflow_dispatch:  # Allow trusted manual runs from the Actions tab
+
+permissions:
+  contents: read
+
+concurrency:
+  group: demo-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'trusted' }}
+  cancel-in-progress: true
 
 env:
   PYTHON_VERSION: "3.11"
@@ -36,21 +43,78 @@ jobs:
         env:
           UV_TORCH_BACKEND: cpu
         run: make install-demo
-      - name: Run demo app
+      - name: Run demo smoke check
+        run: uv run python demo/smoke.py
+      - name: Start demo and wait for health
+        shell: bash
         run: |
-          screen -dm streamlit run demo/app.py --server.port 8080
-          sleep 10 && nc -vz localhost 8080
+          set -euo pipefail
+          log_file="${RUNNER_TEMP}/torchcam-demo.log"
+          uv run streamlit run demo/app.py \
+            --server.headless true \
+            --server.port 8080 \
+            >"${log_file}" 2>&1 &
+          server_pid=$!
+
+          cleanup() {
+            kill "${server_pid}" 2>/dev/null || true
+            wait "${server_pid}" 2>/dev/null || true
+          }
+          trap cleanup EXIT
+
+          if ! python - <<'PY'
+          import time
+          from urllib.request import urlopen
+
+          url = "http://127.0.0.1:8080/_stcore/health"
+          deadline = time.monotonic() + 60
+          last_error = None
+          while time.monotonic() < deadline:
+              try:
+                  with urlopen(url, timeout=2) as response:
+                      if response.status == 200:
+                          raise SystemExit(0)
+              except OSError as exc:
+                  last_error = exc
+              time.sleep(1)
+          raise SystemExit(f"Streamlit health check timed out: {last_error}")
+          PY
+          then
+            cat "${log_file}"
+            exit 1
+          fi
 
   sync-to-hub:
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     needs: build
     steps:
       - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-          lfs: true
-      - name: Push to hub
+      - name: Sync demo to existing Space
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: git push https://frgfm:$HF_TOKEN@huggingface.co/spaces/frgfm/torch-cam main
+        shell: bash
+        run: |
+          set -euo pipefail
+          space_dir="$(mktemp -d)"
+          trap 'rm -rf "${space_dir}"' EXIT
+
+          git clone --depth 1 https://huggingface.co/spaces/frgfm/torch-cam "${space_dir}"
+          mkdir -p "${space_dir}/src"
+          cp demo/app.py "${space_dir}/src/streamlit_app.py"
+          printf 'torchcam[demo] @ git+https://github.com/%s.git@%s\n' \
+            "${GITHUB_REPOSITORY}" "${GITHUB_SHA}" \
+            >"${space_dir}/requirements.txt"
+
+          git -C "${space_dir}" config user.name "github-actions[bot]"
+          git -C "${space_dir}" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git -C "${space_dir}" add requirements.txt src
+          if git -C "${space_dir}" diff --cached --quiet; then
+            echo "Space already matches ${GITHUB_SHA}."
+            exit 0
+          fi
+
+          git -C "${space_dir}" commit -m "sync(demo): ${GITHUB_SHA::7}"
+          git -C "${space_dir}" push \
+            "https://frgfm:${HF_TOKEN}@huggingface.co/spaces/frgfm/torch-cam" \
+            HEAD:main

--- a/demo/app.py
+++ b/demo/app.py
@@ -3,21 +3,50 @@
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 
+import logging
+import warnings
+from contextlib import contextmanager
 from io import BytesIO
+from threading import Lock
+from time import perf_counter
 
-import matplotlib.pyplot as plt
-import requests
 import streamlit as st
 import torch
-from PIL import Image
-from torchvision import models
-from torchvision.transforms.functional import normalize, resize, to_pil_image, to_tensor
+from matplotlib import colormaps
+from PIL import Image, ImageOps
+from torchvision.models import get_model, get_model_weights
+from torchvision.transforms.functional import to_pil_image
 
 from torchcam import methods
-from torchcam.methods._utils import locate_candidate_layer
 from torchcam.utils import overlay_mask
 
-CAM_METHODS = [
+LOGGER = logging.getLogger(__name__)
+MODEL_LABELS = {
+    "resnet18": "ResNet-18",
+    "resnet50": "ResNet-50",
+    "mobilenet_v3_small": "MobileNetV3 Small",
+    "mobilenet_v3_large": "MobileNetV3 Large",
+    "regnet_y_400mf": "RegNet-Y-400MF",
+    "convnext_tiny": "ConvNeXt Tiny",
+    "convnext_small": "ConvNeXt Small",
+    "vit_b_16": "ViT-B/16",
+}
+MODEL_STAGES = {
+    "resnet18": ("layer1", "layer2", "layer3", "layer4"),
+    "resnet50": ("layer1", "layer2", "layer3", "layer4"),
+    "mobilenet_v3_small": ("features.1", "features.3", "features.8", "features.12"),
+    "mobilenet_v3_large": ("features.3", "features.6", "features.12", "features.16"),
+    "regnet_y_400mf": (
+        "trunk_output.block1",
+        "trunk_output.block2",
+        "trunk_output.block3",
+        "trunk_output.block4",
+    ),
+    "convnext_tiny": ("features.1", "features.3", "features.5", "features.7"),
+    "convnext_small": ("features.1", "features.3", "features.5", "features.7"),
+    "vit_b_16": tuple(f"encoder.layers.encoder_layer_{idx}" for idx in range(8, 12)),
+}
+CNN_METHODS = (
     "CAM",
     "GradCAM",
     "GradCAMpp",
@@ -27,123 +56,347 @@ CAM_METHODS = [
     "ISCAM",
     "XGradCAM",
     "LayerCAM",
-]
-TV_MODELS = [
-    "resnet18",
-    "resnet50",
-    "mobilenet_v3_small",
-    "mobilenet_v3_large",
-    "regnet_y_400mf",
-    "convnext_tiny",
-    "convnext_small",
-]
-LABEL_MAP = requests.get(
-    "https://raw.githubusercontent.com/anishathalye/imagenet-simple-labels/master/imagenet-simple-labels.json",
-    timeout=10,
-).json()
+    "FinerCAM",
+    "RefineCAM",
+)
+SLOW_METHODS = {"ScoreCAM", "SSCAM", "ISCAM"}
+
+
+def compatible_methods(model_name):
+    if model_name == "vit_b_16":
+        return ("LeGrad",)
+    return CNN_METHODS[1:] if model_name.startswith("mobilenet_v3") else CNN_METHODS
+
+
+def target_layer_preset(model_name, method_name):
+    stages = MODEL_STAGES[model_name]
+    return stages if method_name in {"RefineCAM", "LeGrad"} else stages[-1:]
+
+
+def parse_target_layers(value, model_name, method_name):
+    if method_name not in compatible_methods(model_name):
+        raise ValueError(f"{method_name} is not supported with {MODEL_LABELS[model_name]}")
+
+    layers = [layer.strip() for layer in value.split("+")]
+    if any(not layer for layer in layers):
+        raise ValueError("Enter target layer names separated by '+'")
+    if len(set(layers)) != len(layers):
+        raise ValueError("Target layers must be unique")
+    if method_name == "RefineCAM" and len(layers) < 2:
+        raise ValueError("RefineCAM requires at least two target layers")
+    if method_name == "LeGrad" and any(not layer.startswith("encoder.layers.encoder_layer_") for layer in layers):
+        raise ValueError("LeGrad target layers must be ViT encoder blocks")
+    return layers
+
+
+def read_image(source):
+    source.seek(0)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", Image.DecompressionBombWarning)
+        with Image.open(source) as image:
+            image.load()
+            return ImageOps.exif_transpose(image).convert("RGB")
+
+
+def preprocess_image(image, weights):
+    transform = weights.transforms()
+    input_tensor = transform(image)
+    mean = input_tensor.new_tensor(transform.mean).view(-1, 1, 1)
+    std = input_tensor.new_tensor(transform.std).view(-1, 1, 1)
+    model_input = to_pil_image(input_tensor.mul(std).add(mean).clamp_(0, 1))
+    return input_tensor, model_input
+
+
+@st.cache_resource(show_spinner=False, max_entries=2)
+def load_model(model_name, device):
+    weights = get_model_weights(model_name).DEFAULT
+    return get_model(model_name, weights=weights).eval().to(device), Lock()
+
+
+@contextmanager
+def preserve_model_state(model):
+    module_modes = [(module, module.training) for module in model.modules()]
+    parameter_flags = [(parameter, parameter.requires_grad) for parameter in model.parameters()]
+    model.zero_grad(set_to_none=True)
+    try:
+        model.eval()
+        with torch.enable_grad():
+            yield
+    finally:
+        model.zero_grad(set_to_none=True)
+        for module, training in module_modes:
+            module.training = training
+        for parameter, requires_grad in parameter_flags:
+            parameter.requires_grad_(requires_grad)
+
+
+def build_extractor(model, method_name, target_layers, finer_gamma=0.6, finer_references=3):
+    if method_name == "CAM":
+        # ponytail: supported torchvision models register the class-output Linear last; use explicit heads if that changes.
+        fc_layer = next(
+            name for name, module in reversed(tuple(model.named_modules())) if isinstance(module, torch.nn.Linear)
+        )
+        return methods.CAM(model, target_layer=target_layers, fc_layer=fc_layer)
+    if method_name == "FinerCAM":
+        return methods.FinerCAM(
+            model,
+            target_layer=target_layers,
+            gamma=finer_gamma,
+            num_references=finer_references,
+        )
+    if method_name == "RefineCAM":
+        return methods.RefineCAM(model, target_layer=target_layers)
+    if method_name == "LeGrad":
+        return methods.LeGrad(model, target_layer=target_layers)
+    return getattr(methods, method_name)(model, target_layer=target_layers)
+
+
+def extract_cam(
+    model,
+    lock,
+    input_tensor,
+    method_name,
+    target_layers,
+    class_idx=None,
+    finer_gamma=0.6,
+    finer_references=3,
+):
+    unknown_layers = [layer for layer in target_layers if layer not in dict(model.named_modules())]
+    if unknown_layers:
+        raise ValueError(f"Unknown target layer(s): {', '.join(unknown_layers)}")
+
+    device = next(model.parameters()).device
+    # ponytail: shared cached models serialize hook mutation; use per-session models if throughput becomes a constraint.
+    with lock, preserve_model_state(model):
+        started_at = perf_counter()
+        with build_extractor(
+            model,
+            method_name,
+            target_layers,
+            finer_gamma,
+            finer_references,
+        ) as extractor:
+            scores = model(input_tensor.unsqueeze(0).to(device))
+            target_idx = int(scores.argmax(dim=1).item()) if class_idx is None else class_idx
+            if not 0 <= target_idx < scores.shape[1]:
+                raise ValueError(f"Class index must be between 0 and {scores.shape[1] - 1}")
+            if method_name == "RefineCAM":
+                cams = extractor(target_idx, scores, target_shape=tuple(input_tensor.shape[-2:]))
+            elif method_name == "LeGrad":
+                cams = extractor(target_idx)
+            else:
+                cams = extractor(target_idx, scores)
+            if len(cams) == 1:
+                cam = cams[0]
+            else:
+                base_extractor = getattr(extractor, "base_cam", extractor)
+                cam = base_extractor.fuse_cams(cams)
+        elapsed = perf_counter() - started_at
+        confidence = float(scores.softmax(dim=1)[0, target_idx].item())
+        return cam.detach().float().cpu(), target_idx, confidence, elapsed
+
+
+def colorize_cam(cam):
+    array = cam.squeeze(0).numpy()
+    return Image.fromarray((255 * colormaps["jet"](array)[..., :3]).astype("uint8"))
+
+
+def image_bytes(image):
+    buffer = BytesIO()
+    image.save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def tensor_bytes(tensor):
+    buffer = BytesIO()
+    torch.save(tensor, buffer)
+    return buffer.getvalue()
+
+
+def compute_result(
+    selected_image,
+    model_name,
+    method_name,
+    target_layer_value,
+    weights,
+    categories,
+    explicit_class_idx,
+    finer_gamma,
+    finer_references,
+):
+    target_layers = parse_target_layers(target_layer_value, model_name, method_name)
+    input_tensor, model_input = preprocess_image(selected_image, weights)
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    try:
+        with st.spinner(f"Loading {MODEL_LABELS[model_name]}…"):
+            model, lock = load_model(model_name, device)
+    except Exception as exc:
+        raise ConnectionError(
+            "The pretrained model could not be loaded. Check connectivity, the model cache, and available memory, then retry."
+        ) from exc
+
+    with st.spinner("Computing the activation map…"):
+        cam, class_idx, confidence, elapsed = extract_cam(
+            model,
+            lock,
+            input_tensor,
+            method_name,
+            target_layers,
+            explicit_class_idx,
+            finer_gamma,
+            int(finer_references),
+        )
+    raw_image = colorize_cam(cam)
+    overlay_image = overlay_mask(
+        model_input,
+        to_pil_image(cam, mode="F"),
+        alpha=0.5,
+    )
+    file_stem = method_name.lower()
+    return {
+        "model": MODEL_LABELS[model_name],
+        "method": method_name,
+        "class_name": categories[class_idx],
+        "confidence": confidence,
+        "layers": " + ".join(target_layers),
+        "elapsed": elapsed,
+        "input_image": model_input,
+        "raw_image": raw_image,
+        "overlay_image": overlay_image,
+        "tensor_bytes": tensor_bytes(cam),
+        "overlay_bytes": image_bytes(overlay_image),
+        "tensor_filename": f"torchcam-{file_stem}.pt",
+        "overlay_filename": f"torchcam-{file_stem}-overlay.png",
+    }
+
+
+def render_comparison(selected_image):
+    result = st.session_state.get("result")
+    st.subheader("Latest result" if result else "CAM comparison")
+    if result:
+        st.caption(
+            f"{result['model']} · {result['method']} · {result['class_name']} "
+            f"({result['confidence']:.1%}) · {result['layers']} · {result['elapsed']:.2f} s"
+        )
+
+    columns = st.columns(3, gap="medium")
+    columns[0].markdown("#### Model input")
+    if result:
+        columns[0].image(result["input_image"], width="stretch")
+    elif selected_image is not None:
+        columns[0].image(selected_image, width="stretch")
+    else:
+        columns[0].info("Upload a PNG or JPEG image to begin.")
+
+    columns[1].markdown("#### Raw CAM")
+    columns[2].markdown("#### Overlay")
+    if not result:
+        columns[1].info("Compute a CAM to see the activation map.")
+        columns[2].info("Compute a CAM to see the overlay.")
+        return
+
+    columns[1].image(result["raw_image"], width="stretch")
+    columns[1].download_button(
+        "Download raw tensor",
+        data=result["tensor_bytes"],
+        file_name=result["tensor_filename"],
+        mime="application/octet-stream",
+        width="stretch",
+    )
+    columns[2].image(result["overlay_image"], width="stretch")
+    columns[2].download_button(
+        "Download overlay",
+        data=result["overlay_bytes"],
+        file_name=result["overlay_filename"],
+        mime="image/png",
+        width="stretch",
+    )
 
 
 def main():
-    # Wide mode
-    st.set_page_config(page_title="TorchCAM - Class activation explorer", layout="wide")
+    st.set_page_config(page_title="TorchCAM Explorer", page_icon="🔎", layout="wide")
+    st.title("TorchCAM Explorer")
+    st.caption("Compare class activation maps from pretrained torchvision models.")
 
-    # Designing the interface
-    st.title("TorchCAM: class activation explorer")
-    # For newline
-    st.write("\n")
-    # Set the columns
-    cols = st.columns((1, 1, 1))
-    cols[0].header("Input image")
-    cols[1].header("Raw CAM")
-    cols[-1].header("Overlayed CAM")
+    with st.sidebar:
+        uploaded_file = st.file_uploader("Input image", type=("png", "jpg", "jpeg"))
+        try:
+            selected_image = read_image(uploaded_file) if uploaded_file is not None else None
+        except (OSError, Image.DecompressionBombError, Image.DecompressionBombWarning):
+            selected_image = None
+            st.error("This image cannot be opened safely. Choose a valid PNG or JPEG file.")
 
-    # Sidebar
-    # File selection
-    st.sidebar.title("Input selection")
-    # Choose your own image
-    uploaded_file = st.sidebar.file_uploader("Upload files", type=["png", "jpeg", "jpg"])
-    if uploaded_file is not None:
-        img = Image.open(BytesIO(uploaded_file.read()), mode="r").convert("RGB")
-
-        cols[0].image(img, use_container_width=True)
-
-    # Model selection
-    st.sidebar.title("Setup")
-    tv_model = st.sidebar.selectbox(
-        "Classification model",
-        TV_MODELS,
-        help="Supported models from Torchvision",
-    )
-    default_layer = ""
-    if tv_model is not None:
-        with st.spinner("Loading model..."):
-            model = models.__dict__[tv_model](pretrained=True).eval()
-        default_layer = locate_candidate_layer(model, (3, 224, 224))
-
-    if torch.cuda.is_available():
-        model = model.cuda()
-
-    target_layer = st.sidebar.text_input(
-        "Target layer",
-        default_layer,
-        help='If you want to target several layers, add a "+" separator (e.g. "layer3+layer4")',
-    )
-    cam_method = st.sidebar.selectbox(
-        "CAM method",
-        CAM_METHODS,
-        help="The way your class activation map will be computed",
-    )
-    if cam_method is not None:
-        cam_extractor = methods.__dict__[cam_method](
-            model,
-            target_layer=[s.strip() for s in target_layer.split("+")] if len(target_layer) > 0 else None,
+        st.header("Configuration")
+        model_name = st.selectbox(
+            "Classification model",
+            tuple(MODEL_LABELS),
+            format_func=MODEL_LABELS.__getitem__,
         )
+        method_name = st.selectbox("CAM method", compatible_methods(model_name))
+        weights = get_model_weights(model_name).DEFAULT
+        categories = weights.meta["categories"]
 
-    class_choices = [f"{idx + 1} - {class_name}" for idx, class_name in enumerate(LABEL_MAP)]
-    class_selection = st.sidebar.selectbox("Class selection", ["Predicted class (argmax)", *class_choices])
+        class_mode = st.radio("Target class", ("Predicted class", "Choose a class"))
+        explicit_class_idx = None
+        if class_mode == "Choose a class":
+            explicit_class_idx = st.selectbox(
+                "ImageNet class",
+                range(len(categories)),
+                format_func=categories.__getitem__,
+            )
 
-    # For newline
-    st.sidebar.write("\n")
-
-    if st.sidebar.button("Compute CAM"):
-        if uploaded_file is None:
-            st.sidebar.error("Please upload an image first")
-
-        else:
-            with st.spinner("Analyzing..."):
-                # Preprocess image
-                img_tensor = normalize(
-                    to_tensor(resize(img, (224, 224))),
-                    [0.485, 0.456, 0.406],
-                    [0.229, 0.224, 0.225],
+        finer_gamma = 0.6
+        finer_references = 3
+        preset = "+".join(target_layer_preset(model_name, method_name))
+        with st.expander("Method settings"):
+            target_layer_value = st.text_input(
+                "Target layers",
+                value=preset,
+                key=f"target-layers-{model_name}-{method_name}",
+                help="Separate multiple module names with '+'.",
+            )
+            if method_name == "FinerCAM":
+                finer_gamma = st.number_input("Comparison strength", min_value=0.0, value=0.6, step=0.1)
+                finer_references = st.number_input(
+                    "Automatic comparison classes",
+                    min_value=1,
+                    max_value=len(categories) - 1,
+                    value=3,
+                    step=1,
                 )
 
-                if torch.cuda.is_available():
-                    img_tensor = img_tensor.cuda()
+        if method_name in SLOW_METHODS:
+            st.warning(f"{method_name} performs extra forward passes and can be slow on CPU.")
+        elif method_name == "LeGrad":
+            st.info("LeGrad is limited to ViT-B/16 and its final four encoder blocks in this demo.")
 
-                # Forward the image to the model
-                out = model(img_tensor.unsqueeze(0))
-                # Select the target class
-                if class_selection == "Predicted class (argmax)":
-                    class_idx = out.squeeze(0).argmax().item()
-                else:
-                    class_idx = LABEL_MAP.index(class_selection.rpartition(" - ")[-1])
-                # Retrieve the CAM
-                act_maps = cam_extractor(class_idx, out)
-                # Fuse the CAMs if there are several
-                activation_map = act_maps[0] if len(act_maps) == 1 else cam_extractor.fuse_cams(act_maps)
-                # Plot the raw heatmap
-                fig, ax = plt.subplots()
-                ax.imshow(activation_map.squeeze(0).cpu().numpy())
-                ax.axis("off")
-                cols[1].pyplot(fig)
+        compute = st.button("Compute CAM", type="primary", width="stretch", disabled=selected_image is None)
 
-                # Overlayed CAM
-                fig, ax = plt.subplots()
-                result = overlay_mask(img, to_pil_image(activation_map, mode="F"), alpha=0.5)
-                ax.imshow(result)
-                ax.axis("off")
-                cols[-1].pyplot(fig)
+    if compute:
+        try:
+            result = compute_result(
+                selected_image,
+                model_name,
+                method_name,
+                target_layer_value,
+                weights,
+                categories,
+                explicit_class_idx,
+                finer_gamma,
+                finer_references,
+            )
+        except ConnectionError as exc:
+            LOGGER.exception("Unable to load pretrained model")
+            st.error(str(exc))
+        except (AssertionError, RuntimeError, TypeError, ValueError) as exc:
+            st.error(f"The CAM could not be computed: {exc}")
+        except Exception:
+            LOGGER.exception("Unexpected CAM extraction failure")
+            st.error("The CAM could not be computed. Check the selected layers and retry.")
+        else:
+            st.session_state["result"] = result
+
+    render_comparison(selected_image)
 
 
 if __name__ == "__main__":

--- a/demo/smoke.py
+++ b/demo/smoke.py
@@ -1,0 +1,78 @@
+# Copyright (C) 2021-2026, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
+
+import gc
+from threading import Lock
+
+import torch
+from torchvision.models import get_model
+
+import app
+
+
+def check(condition, message):
+    if not condition:
+        raise AssertionError(message)
+
+
+def hook_count(model):
+    return sum(
+        len(module._forward_hooks) + len(module._forward_pre_hooks) + len(module._backward_hooks)  # noqa: SLF001
+        for module in model.modules()
+    )
+
+
+def main():
+    check(app.compatible_methods("vit_b_16") == ("LeGrad",), "ViT compatibility changed")
+    check("LeGrad" not in app.compatible_methods("resnet18"), "LeGrad must stay ViT-only")
+    check("FinerCAM" in app.compatible_methods("resnet18"), "FinerCAM is missing")
+    check("RefineCAM" in app.compatible_methods("resnet18"), "RefineCAM is missing")
+
+    for model_name in app.MODEL_LABELS:
+        model = get_model(model_name, weights=None)
+        module_names = dict(model.named_modules())
+        for method_name in app.compatible_methods(model_name):
+            preset = app.target_layer_preset(model_name, method_name)
+            for layer in preset:
+                check(layer in module_names, f"Unknown {model_name} preset: {layer}")
+            if method_name == "CAM":
+                with app.build_extractor(model, method_name, list(preset)):
+                    pass
+        check(hook_count(model) == 0, f"Hooks leaked while checking {model_name}")
+        del model
+        gc.collect()
+
+    model = get_model("resnet18", weights=None).train()
+    module_modes = [module.training for module in model.modules()]
+    parameter_flags = [parameter.requires_grad for parameter in model.parameters()]
+    input_tensor = torch.rand(3, 64, 64)
+
+    cam, _, _, _ = app.extract_cam(model, Lock(), input_tensor, "GradCAM", ["layer4"])
+    check(tuple(cam.shape) == (1, 2, 2), "Unexpected GradCAM shape")
+    check(hook_count(model) == 0, "Hooks leaked after successful extraction")
+    check([module.training for module in model.modules()] == module_modes, "Module modes were not restored")
+    check(
+        [parameter.requires_grad for parameter in model.parameters()] == parameter_flags,
+        "Parameter flags were not restored",
+    )
+    check(all(parameter.grad is None for parameter in model.parameters()), "Parameter gradients were not cleared")
+
+    try:
+        app.extract_cam(model, Lock(), input_tensor, "GradCAM", ["layer4"], class_idx=1000)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("Invalid class index did not fail")
+    check(hook_count(model) == 0, "Hooks leaked after failed extraction")
+    check([module.training for module in model.modules()] == module_modes, "Failure changed module modes")
+    check(
+        [parameter.requires_grad for parameter in model.parameters()] == parameter_flags,
+        "Failure changed parameter flags",
+    )
+    check(all(parameter.grad is None for parameter in model.parameters()), "Failure left parameter gradients")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ docs = [
     "mkdocs-llmstxt==0.4.0",
 ]
 demo = [
-    "streamlit>=1.40.0,<2.0.0",
+    "streamlit>=1.61.0,<2.0.0",
     "torchvision>=0.15.0,<1.0.0",
 ]
 scripts = [


### PR DESCRIPTION
## Summary

- modernize the demo for Streamlit 1.61 around torchvision's weights API, bounded resource caching, per-model extraction locking, and deterministic hook/state cleanup
- keep the three-panel experience with a user-uploaded image, predicted/explicit targets, editable method settings, persistent results, and PNG/raw-tensor downloads
- add an offline smoke check plus a bounded Streamlit health probe
- synchronize the existing Hugging Face Space through its own Git history after trusted main builds, without force-pushing or exposing `HF_TOKEN` to PR jobs

## Support matrix

| Model family | Exposed methods |
|---|---|
| ResNet-18/50, RegNet-Y-400MF, ConvNeXt Tiny/Small | CAM, GradCAM, GradCAM++, SmoothGradCAM++, XGradCAM, LayerCAM, ScoreCAM, SSCAM, ISCAM, FinerCAM, RefineCAM |
| MobileNetV3 Small/Large | GradCAM, GradCAM++, SmoothGradCAM++, XGradCAM, LayerCAM, ScoreCAM, SSCAM, ISCAM, FinerCAM, RefineCAM |
| torchvision ViT-B/16 | LeGrad only |

CNN methods remain hidden for ViT; LeGrad remains hidden for CNNs. CAM is hidden for MobileNetV3 because its nonlinear two-layer classifier is not CAM-compatible. ScoreCAM, SSCAM, and ISCAM show a CPU-cost warning.

## Deployment

- PRs are build-only; deployment runs after a successful main push or trusted manual dispatch
- distinct PR/trusted concurrency groups cancel superseded jobs without racing main deployments
- the deploy step clones the existing Space, maps the demo into `src/`, pins `torchcam[demo]` to the exact GitHub SHA, commits, and pushes normally
- the Space Dockerfile, root metadata, and independent history are preserved

## Validation

- `UV_TORCH_BACKEND=cpu UV_PYTHON=3.12 uv run --isolated --extra demo python demo/smoke.py` — passed
- `UV_PYTHON=3.12 make quality` — Ruff, formatting, ty, and dependency sync passed
- `UV_PYTHON=3.12 uv run --extra test pytest --cov-report xml` — 122 passed, 1 skipped
- `DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/opt/cairo/lib:/opt/homebrew/lib UV_PYTHON=3.12 uv run --extra docs mkdocs build --strict -f docs/mkdocs.yml` — passed
- pretrained ResNet-18 image: GradCAM 0.053 s, FinerCAM 0.043 s, RefineCAM 0.051 s; finite outputs and zero residual hooks after each run
- offline advertised CAM matrix: ResNet-18/50, RegNet-Y-400MF, and ConvNeXt Tiny/Small extracted successfully with zero residual hooks; MobileNetV3 correctly excluded CAM
- ViT-B/16 LeGrad, two CPU threads, three runs: 0.081 s median extraction, 1,146.6 MB peak RSS, finite output, zero residual hooks (local Darwin arm64; not live-Space acceptance)
- real Streamlit 1.61 app: health, generated in-memory upload, predicted/explicit targets, both downloads, corrupt-image and invalid-layer recovery, repeat extraction, keyboard focus, 1440 px layout, 390 px stacking, and zero horizontal overflow passed

## Screenshots

### 1440 px desktop

![TorchCAM Streamlit demo at 1440 px](https://gist.githubusercontent.com/frgfm/e76a26ac524b8e71e7fba2dd1e46937d/raw/91274ed4ce8501dff58de161c6a79287e93f5767/torchcam-demo-desktop-upload.png)

### 390 px narrow

![TorchCAM Streamlit demo at 390 px](https://gist.githubusercontent.com/frgfm/e76a26ac524b8e71e7fba2dd1e46937d/raw/91274ed4ce8501dff58de161c6a79287e93f5767/torchcam-demo-narrow-upload.png)

Closes #177
