### PR TITLE
feat(metrics): add deletion and insertion faithfulness

### DIFF
--- a/docs/docs/reference/metrics.md
+++ b/docs/docs/reference/metrics.md
@@ -2,9 +2,80 @@
 
 Apart from qualitative visual comparison, it is important to have a refined evaluation metric for class activation maps. This submodule is dedicated to the evaluation of CAM methods.
 
+## Classification confidence
+
 ![Average Drop and Increase in Confidence compare the selected-class score on the original and CAM-masked inputs.](../img/classification-metrics.svg)
 
 ::: torchcam.metrics.ClassificationMetric
+    options:
+        members:
+            - reset
+            - update
+            - summary
+
+## Deletion and insertion faithfulness
+
+[Deletion and insertion](https://arxiv.org/abs/1806.07421) measure how the model's selected-class score changes as spatial positions are perturbed in descending CAM order. For an input $X$, baseline $B$, and the set $R_t$ containing the top-ranked positions restored or removed by step $t$:
+
+$$
+D_t[p] =
+\begin{cases}
+B[p] & p \in R_t \\
+X[p] & p \notin R_t
+\end{cases}
+$$
+
+$$
+I_t[p] =
+\begin{cases}
+X[p] & p \in R_t \\
+B[p] & p \notin R_t.
+\end{cases}
+$$
+
+The same spatial mask is applied to every input channel. If $x_t = |R_t| / P$ is the actual perturbed fraction for $P$ spatial positions and $s_c$ is the selected-class score, TorchCAM computes:
+
+$$
+\operatorname{DeletionAUC} = \operatorname{trapz}(s_c(D_t), x_t),
+$$
+
+$$
+\operatorname{InsertionAUC} = \operatorname{trapz}(s_c(I_t), x_t).
+$$
+
+Lower deletion AUC and higher insertion AUC indicate a more faithful ranking. Both the unperturbed and fully perturbed endpoints are included. `steps` is the maximum number of intervals: each interval changes $\lceil P / \text{steps} \rceil$ positions, except for the shorter final interval, and integration uses the resulting fractions rather than an assumed uniform grid.
+
+The default baseline is `zeros_like(input_tensor)`. This represents the dataset mean only when inputs were normalized so that the mean maps to zero. Baseline choice can introduce out-of-distribution evidence and materially change both scores. The original RISE evaluation used constant deletion values and a blurred insertion substrate, while this metric deliberately uses one baseline for both curves. To reproduce those two substrates, run the metric separately with each baseline and compare only the corresponding AUC.
+
+`batch_size` limits how many perturbed inputs are scored in one forward pass. It bounds temporary memory but does not reduce the number of perturbed samples. With $S$ effective intervals, each valid input requires $2S - 1$ additional scoring samples, plus the original CAM-producing forward and any backward pass required by the extractor.
+
+By default, the metric integrates raw model outputs. Pass a function such as softmax for probability curves comparable to the paper; raw-logit AUCs may fall outside $[0, 1]$ and should not be compared with probability AUCs.
+
+```python
+from functools import partial
+
+import torch
+
+from torchcam.methods import GradCAM
+from torchcam.metrics import DeletionInsertionMetric
+
+model.eval()
+with GradCAM(model, "layer4") as cam_extractor:
+    metric = DeletionInsertionMetric(
+        cam_extractor,
+        partial(torch.softmax, dim=-1),
+        steps=20,
+        batch_size=32,
+    )
+    metric.update(input_tensor)
+    scores = metric.summary()
+```
+
+!!! warning
+
+    Deletion and insertion test perturbation faithfulness to the model's score. They do not establish localization quality, human interpretability, or causal correctness outside the chosen perturbation and baseline protocol.
+
+::: torchcam.metrics.DeletionInsertionMetric
     options:
         members:
             - reset

--- a/scripts/eval_perf.py
+++ b/scripts/eval_perf.py
@@ -21,7 +21,7 @@ from torchvision.transforms import v2 as T
 from torchvision.transforms.functional import InterpolationMode
 
 from torchcam import methods
-from torchcam.metrics import ClassificationMetric
+from torchcam.metrics import ClassificationMetric, DeletionInsertionMetric
 
 
 def main(args):
@@ -65,6 +65,16 @@ def main(args):
     # Hook the corresponding layer in the model
     with methods.__dict__[args.method](model, args.target.split(",") if args.target else None) as cam_extractor:
         metric = ClassificationMetric(cam_extractor, partial(torch.softmax, dim=-1))
+        deletion_insertion_metric = (
+            DeletionInsertionMetric(
+                cam_extractor,
+                partial(torch.softmax, dim=-1),
+                steps=args.di_steps,
+                batch_size=args.di_batch_size,
+            )
+            if args.deletion_insertion
+            else None
+        )
 
         # Evaluation runs
         for x, _ in loader:
@@ -72,12 +82,21 @@ def main(args):
             x = x.to(device=device)
             x.requires_grad_(True)
             metric.update(x)
+            if deletion_insertion_metric is not None:
+                model.zero_grad()
+                deletion_insertion_metric.update(x.detach().requires_grad_(True))
 
     print(f"{args.method} w/ {args.arch} (validation set of Imagenette on ({args.size}, {args.size}) inputs)")
     metrics_dict = metric.summary()
     print(
         f"Average Drop {metrics_dict['avg_drop']:.2%}, Increase in Confidence {metrics_dict['conf_increase']:.2%}, Skipped {metric.nan_count} samples"
     )
+    if deletion_insertion_metric is not None:
+        faithfulness = deletion_insertion_metric.summary()
+        print(
+            f"Deletion AUC {faithfulness['deletion_auc']:.4f}, Insertion AUC {faithfulness['insertion_auc']:.4f}, "
+            f"Skipped {deletion_insertion_metric.nan_count} samples"
+        )
 
 
 if __name__ == "__main__":
@@ -96,6 +115,13 @@ if __name__ == "__main__":
     parser.add_argument("--target", type=str, default=None, help="Target layer name")
     parser.add_argument("--size", type=int, default=224, help="The image input size")
     parser.add_argument("-b", "--batch-size", default=32, type=int, help="batch size")
+    parser.add_argument(
+        "--deletion-insertion",
+        action="store_true",
+        help="also compute deletion and insertion faithfulness AUCs",
+    )
+    parser.add_argument("--di-steps", default=20, type=int, help="maximum deletion/insertion perturbation intervals")
+    parser.add_argument("--di-batch-size", default=32, type=int, help="deletion/insertion perturbation chunk size")
     parser.add_argument(
         "--device",
         type=str,

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -210,6 +210,31 @@ def test_deletion_insertion_class_indices(class_idx, expected):
     assert set(metric.summary()) == {"deletion_auc", "insertion_auc"}
 
 
+@pytest.mark.parametrize(
+    ("class_idx", "error"),
+    [
+        (2, ValueError),
+        ("0", TypeError),
+        ([0], ValueError),
+        ([0, 2], ValueError),
+        ([False, 0], TypeError),
+    ],
+)
+def test_metrics_reject_invalid_class_indices(class_idx, error):
+    extractor = _FixedExtractor(_SumClassifier(), _exact_input().squeeze(1))
+    metric = metrics.ClassificationMetric(extractor)
+
+    with pytest.raises(error):
+        metric.update(_exact_input().expand(2, -1, -1, -1), class_idx=class_idx)
+
+
+def test_metrics_reject_unsupported_spatial_rank():
+    extractor = _FixedExtractor(_SumClassifier(), _exact_input().squeeze(1))
+
+    with pytest.raises(ValueError, match="1D"):
+        metrics.ClassificationMetric(extractor).update(torch.ones((1, 1)), class_idx=0)
+
+
 @pytest.mark.parametrize("metric_cls", [metrics.ClassificationMetric, metrics.DeletionInsertionMetric])
 def test_metrics_skip_nan_cams(metric_cls):
     model = _SumClassifier()
@@ -351,9 +376,24 @@ def test_deletion_insertion_reset():
         ({"steps": 0}, ValueError),
         ({"steps": 1.5}, TypeError),
         ({"batch_size": 0}, ValueError),
+        ({"batch_size": 1.5}, TypeError),
         ({"baseline": 0}, TypeError),
     ],
 )
 def test_deletion_insertion_rejects_invalid_configuration(kwargs, error):
     with pytest.raises(error):
         metrics.DeletionInsertionMetric(_FixedExtractor(_SumClassifier(), _exact_input().squeeze(1)), **kwargs)
+
+
+@pytest.mark.parametrize(
+    ("baseline", "error"),
+    [
+        (lambda _input: 0, TypeError),
+        (torch.zeros((3, 3)), ValueError),
+    ],
+)
+def test_deletion_insertion_rejects_invalid_baseline_result(baseline, error):
+    metric = _fixed_metric(baseline=baseline)
+
+    with pytest.raises(error):
+        metric.update(_exact_input(), class_idx=0)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,22 +1,359 @@
+from contextlib import contextmanager
 from functools import partial
 
+import pytest
 import torch
-from torchvision.models import get_model
+from torch import nn
 
 from torchcam import metrics
-from torchcam.methods import LayerCAM
+from torchcam.methods import FinerCAM, LayerCAM, RefineCAM
+
+
+class _SumClassifier(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.identity = nn.Identity()
+        self.calls = 0
+        self.fail_on_call = None
+        self.seen = []
+
+    def forward(self, input_tensor):
+        self.calls += 1
+        if self.calls == self.fail_on_call:
+            raise RuntimeError("scoring failed")
+        self.seen.append(input_tensor.detach().clone())
+        score = self.identity(input_tensor).flatten(1).sum(dim=1)
+        return torch.stack((score, 1 - score), dim=1)
+
+
+class _ConvClassifier(nn.Module):
+    def __init__(self, spatial_dims=2):
+        super().__init__()
+        conv = nn.Conv2d if spatial_dims == 2 else nn.Conv3d
+        self.conv1 = conv(1, 1, 1, bias=False)
+        self.conv2 = conv(1, 1, 1, bias=False)
+        with torch.no_grad():
+            self.conv1.weight.fill_(1)
+            self.conv2.weight.fill_(1)
+
+    def forward(self, input_tensor):
+        score = self.conv2(self.conv1(input_tensor)).flatten(1).sum(dim=1)
+        return torch.stack((score, 1 - score), dim=1)
+
+
+class _FixedExtractor:
+    def __init__(self, model, cam):
+        self.model = model
+        self.cam = cam
+        self._hooks_enabled = True
+        self.class_idx = None
+
+    def __call__(self, class_idx, scores=None, _normalized=True, **_kwargs):
+        self.class_idx = class_idx
+        cam = self.cam.to(scores)
+        if cam.shape[0] == 1 and scores.shape[0] > 1:
+            cam = cam.expand(scores.shape[0], *cam.shape[1:])
+        return [cam.clone()]
+
+    @staticmethod
+    def fuse_cams(cams):
+        return torch.stack(cams).max(dim=0).values
+
+    @contextmanager
+    def _hooks_off(self):
+        previous = self._hooks_enabled
+        self._hooks_enabled = False
+        try:
+            yield
+        finally:
+            self._hooks_enabled = previous
+
+
+def _exact_input():
+    return torch.tensor([[[[0.4, 0.3], [0.2, 0.1]]]])
+
+
+def _fixed_metric(*, steps=2, batch_size=32, baseline=None):
+    model = _SumClassifier()
+    extractor = _FixedExtractor(model, _exact_input().squeeze(1))
+    return metrics.DeletionInsertionMetric(
+        extractor,
+        steps=steps,
+        batch_size=batch_size,
+        baseline=baseline,
+    )
 
 
 def test_classification_metric():
-    model = get_model("mobilenet_v3_small", weights=None)
-    with LayerCAM(model, "features.12") as extractor:
+    model = _ConvClassifier()
+    model.train()
+    model.conv1.eval()
+    modes = [module.training for module in model.modules()]
+    input_tensor = _exact_input().expand(2, -1, -1, -1).clone().requires_grad_(True)
+
+    with LayerCAM(model, "conv2") as extractor:
         metric = metrics.ClassificationMetric(extractor, partial(torch.softmax, dim=-1))
+        metric.update(input_tensor, class_idx=0)
+        metric.update(input_tensor, class_idx=[0, 0])
+        metric.update(input_tensor)
+        assert extractor._hooks_enabled
 
-        # Fixed class
-        metric.update(torch.rand((2, 3, 224, 224), dtype=torch.float32), class_idx=0)
-        # Top predicted class
-        metric.update(torch.rand((2, 3, 224, 224), dtype=torch.float32))
-    out = metric.summary()
+    assert metric.summary().keys() == {"avg_drop", "conf_increase"}
+    assert all(0 <= value <= 1 for value in metric.summary().values())
+    assert metric.total == 6
+    assert metric.nan_count == 0
+    assert [module.training for module in model.modules()] == modes
 
-    assert len(out) == 2
-    assert all(0 <= v <= 1 for v in out.values())
+
+def test_classification_metric_exact_value():
+    model = _SumClassifier()
+    extractor = _FixedExtractor(model, torch.tensor([[[1.0, 0.0], [0.0, 0.0]]]))
+    metric = metrics.ClassificationMetric(extractor)
+
+    metric.update(_exact_input(), class_idx=0)
+
+    assert metric.summary() == pytest.approx({"avg_drop": 0.6 / (1 + 1e-7), "conf_increase": 0})
+
+
+def test_deletion_insertion_complete_curves_and_auc():
+    metric = _fixed_metric(steps=2)
+    input_tensor = _exact_input()
+    original_scores = metric.cam_extractor.model(input_tensor)[:, 0]
+    fractions, deletion, insertion = metric._compute_curves(
+        input_tensor,
+        torch.zeros_like(input_tensor),
+        torch.arange(4).unsqueeze(0),
+        torch.tensor([0]),
+        original_scores,
+    )
+
+    torch.testing.assert_close(fractions, torch.tensor([0.0, 0.5, 1.0]))
+    torch.testing.assert_close(deletion, torch.tensor([[1.0, 0.3, 0.0]]))
+    torch.testing.assert_close(insertion, torch.tensor([[0.0, 0.7, 1.0]]))
+    assert torch.trapezoid(deletion, fractions).item() == pytest.approx(0.4)
+    assert torch.trapezoid(insertion, fractions).item() == pytest.approx(0.6)
+
+    metric.update(input_tensor, class_idx=0)
+    assert metric.summary() == pytest.approx({"deletion_auc": 0.4, "insertion_auc": 0.6})
+
+
+def test_deletion_insertion_non_divisible_steps():
+    metric = _fixed_metric(steps=3)
+    input_tensor = torch.tensor([[[[0.3, 0.25, 0.2, 0.15, 0.1]]]])
+    original_scores = metric.cam_extractor.model(input_tensor)[:, 0]
+    fractions, deletion, insertion = metric._compute_curves(
+        input_tensor,
+        torch.zeros_like(input_tensor),
+        torch.arange(5).unsqueeze(0),
+        torch.tensor([0]),
+        original_scores,
+    )
+
+    torch.testing.assert_close(fractions, torch.tensor([0.0, 0.4, 0.8, 1.0]))
+    torch.testing.assert_close(deletion, torch.tensor([[1.0, 0.45, 0.1, 0.0]]))
+    torch.testing.assert_close(insertion, torch.tensor([[0.0, 0.55, 0.9, 1.0]]))
+    assert torch.trapezoid(deletion, fractions).item() == pytest.approx(0.41)
+    assert torch.trapezoid(insertion, fractions).item() == pytest.approx(0.59)
+
+
+def test_deletion_insertion_chunked_parity():
+    input_tensor = _exact_input().expand(2, -1, -1, -1).clone()
+    chunked = _fixed_metric(steps=4, batch_size=1)
+    unchunked = _fixed_metric(steps=4, batch_size=100)
+
+    chunked.update(input_tensor, class_idx=[0, 0])
+    unchunked.update(input_tensor, class_idx=[0, 0])
+
+    assert chunked.summary() == pytest.approx(unchunked.summary())
+
+
+def test_deletion_insertion_custom_baselines_and_non_mutation():
+    input_tensor = _exact_input()
+    original_input = input_tensor.clone()
+    baseline = torch.tensor(0.05)
+    original_baseline = baseline.clone()
+    calls = 0
+
+    def baseline_fn(_tensor):
+        nonlocal calls
+        calls += 1
+        return baseline
+
+    tensor_metric = _fixed_metric(baseline=baseline)
+    callable_metric = _fixed_metric(baseline=baseline_fn)
+    tensor_metric.update(input_tensor, class_idx=0)
+    callable_metric.update(input_tensor, class_idx=0)
+
+    assert tensor_metric.summary() == pytest.approx(callable_metric.summary())
+    assert calls == 1
+    torch.testing.assert_close(input_tensor, original_input)
+    torch.testing.assert_close(baseline, original_baseline)
+
+
+@pytest.mark.parametrize(
+    ("class_idx", "expected"),
+    [
+        (0, 0),
+        ([0, 1], [0, 1]),
+        (None, [0, 1]),
+    ],
+)
+def test_deletion_insertion_class_indices(class_idx, expected):
+    model = _SumClassifier()
+    extractor = _FixedExtractor(model, _exact_input().squeeze(1))
+    metric = metrics.DeletionInsertionMetric(extractor, steps=2)
+    input_tensor = torch.cat((_exact_input(), _exact_input() / 5))
+
+    metric.update(input_tensor, class_idx=class_idx)
+
+    assert extractor.class_idx == expected
+    assert set(metric.summary()) == {"deletion_auc", "insertion_auc"}
+
+
+@pytest.mark.parametrize("metric_cls", [metrics.ClassificationMetric, metrics.DeletionInsertionMetric])
+def test_metrics_skip_nan_cams(metric_cls):
+    model = _SumClassifier()
+    cam = torch.stack((_exact_input().squeeze(0).squeeze(0), torch.full((2, 2), float("nan"))))
+    extractor = _FixedExtractor(model, cam)
+    input_tensor = _exact_input().expand(2, -1, -1, -1).clone()
+    metric = (
+        metric_cls(extractor)
+        if metric_cls is metrics.ClassificationMetric
+        else metric_cls(extractor, steps=2, baseline=torch.zeros_like(input_tensor))
+    )
+
+    metric.update(input_tensor, class_idx=[0, 0])
+
+    assert metric.total == 1
+    assert metric.nan_count == 1
+
+
+@pytest.mark.parametrize("metric_cls", [metrics.ClassificationMetric, metrics.DeletionInsertionMetric])
+def test_metrics_all_nan_cams(metric_cls):
+    model = _SumClassifier()
+    extractor = _FixedExtractor(model, torch.full((1, 2, 2), float("nan")))
+    metric = metric_cls(extractor) if metric_cls is metrics.ClassificationMetric else metric_cls(extractor, steps=2)
+
+    metric.update(_exact_input())
+
+    assert metric.nan_count == 1
+    with pytest.raises(AssertionError, match="update"):
+        metric.summary()
+
+
+@pytest.mark.parametrize("metric_cls", [metrics.ClassificationMetric, metrics.DeletionInsertionMetric])
+@pytest.mark.parametrize("spatial_dims", [2, 3])
+def test_metrics_spatial_inputs(metric_cls, spatial_dims):
+    model = _ConvClassifier(spatial_dims)
+    shape = (1, 1, 2, 2) if spatial_dims == 2 else (1, 1, 2, 2, 2)
+    input_tensor = torch.full(shape, 1 / (2**spatial_dims))
+
+    with LayerCAM(model, "conv2") as extractor:
+        metric = (
+            metric_cls(extractor)
+            if metric_cls is metrics.ClassificationMetric
+            else metric_cls(extractor, steps=2, batch_size=2)
+        )
+        metric.update(input_tensor, class_idx=0)
+
+    assert all(torch.isfinite(torch.tensor(list(metric.summary().values()))))
+
+
+@pytest.mark.parametrize(
+    "extractor_factory",
+    [
+        pytest.param(lambda model: LayerCAM(model, "conv2"), id="ordinary"),
+        pytest.param(lambda model: LayerCAM(model, ["conv1", "conv2"]), id="multi-layer"),
+        pytest.param(
+            lambda model: RefineCAM(model, ["conv1", "conv2"], base_method=LayerCAM),
+            id="refinecam-wrapper",
+        ),
+        pytest.param(
+            lambda model: FinerCAM(model, "conv2", base_method=LayerCAM, num_references=1),
+            id="finercam-wrapper",
+        ),
+    ],
+)
+def test_deletion_insertion_extractor_protocols(extractor_factory):
+    model = _ConvClassifier()
+    input_tensor = torch.full((1, 1, 2, 2), 0.25)
+
+    with extractor_factory(model) as extractor:
+        metric = metrics.DeletionInsertionMetric(extractor, partial(torch.softmax, dim=-1), steps=1)
+        metric.update(input_tensor)
+        hook_owner = getattr(extractor, "base_cam", extractor)
+        hooks_enabled = hook_owner._hooks_enabled
+
+    assert hooks_enabled
+    assert set(metric.summary()) == {"deletion_auc", "insertion_auc"}
+
+
+@pytest.mark.parametrize(
+    ("device", "dtype"),
+    [
+        (torch.device("cpu"), torch.float64),
+        pytest.param(
+            torch.device("cuda"),
+            torch.float64,
+            marks=pytest.mark.skipif(not torch.cuda.is_available(), reason="no CUDA"),
+        ),
+        pytest.param(
+            torch.device("mps"),
+            torch.float32,
+            marks=pytest.mark.skipif(not torch.backends.mps.is_available(), reason="no MPS"),
+        ),
+    ],
+)
+def test_deletion_insertion_preserves_dtype_and_device(device, dtype):
+    model = _SumClassifier().to(device=device, dtype=dtype)
+    extractor = _FixedExtractor(model, _exact_input().squeeze(1))
+    metric = metrics.DeletionInsertionMetric(extractor, steps=2, batch_size=1)
+    input_tensor = _exact_input().to(device=device, dtype=dtype)
+
+    metric.update(input_tensor, class_idx=0)
+
+    assert all(tensor.device.type == device.type and tensor.dtype == dtype for tensor in model.seen)
+
+
+@pytest.mark.parametrize("metric_cls", [metrics.ClassificationMetric, metrics.DeletionInsertionMetric])
+def test_metrics_restore_model_and_hooks_on_scoring_error(metric_cls):
+    model = _SumClassifier()
+    model.train()
+    model.identity.eval()
+    modes = [module.training for module in model.modules()]
+    model.fail_on_call = 2
+    extractor = _FixedExtractor(model, _exact_input().squeeze(1))
+    metric = metric_cls(extractor) if metric_cls is metrics.ClassificationMetric else metric_cls(extractor, steps=2)
+
+    with pytest.raises(RuntimeError, match="scoring failed"):
+        metric.update(_exact_input(), class_idx=0)
+
+    assert [module.training for module in model.modules()] == modes
+    assert extractor._hooks_enabled
+    assert metric.total == 0
+
+
+def test_deletion_insertion_reset():
+    metric = _fixed_metric()
+    metric.update(_exact_input(), class_idx=0)
+
+    metric.reset()
+
+    assert metric.deletion == metric.insertion == 0
+    assert metric.total == metric.nan_count == 0
+    with pytest.raises(AssertionError, match="update"):
+        metric.summary()
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "error"),
+    [
+        ({"steps": 0}, ValueError),
+        ({"steps": 1.5}, TypeError),
+        ({"batch_size": 0}, ValueError),
+        ({"baseline": 0}, TypeError),
+    ],
+)
+def test_deletion_insertion_rejects_invalid_configuration(kwargs, error):
+    with pytest.raises(error):
+        metrics.DeletionInsertionMetric(_FixedExtractor(_SumClassifier(), _exact_input().squeeze(1)), **kwargs)

--- a/torchcam/metrics.py
+++ b/torchcam/metrics.py
@@ -277,27 +277,6 @@ class DeletionInsertionMetric:
         except RuntimeError as exc:
             raise ValueError("baseline must be broadcastable to the input shape") from exc
 
-    def _score_perturbations(
-        self,
-        input_tensor: torch.Tensor,
-        baseline: torch.Tensor,
-        ranks: torch.Tensor,
-        target_indices: torch.Tensor,
-        jobs: list[tuple[int, int, int, int]],
-    ) -> torch.Tensor:
-        sample_indices = torch.tensor([job[0] for job in jobs], device=input_tensor.device)
-        curve_indices = torch.tensor([job[1] for job in jobs], device=input_tensor.device)
-        perturb_counts = torch.tensor([job[3] for job in jobs], device=input_tensor.device)
-        relevant = ranks[sample_indices] < perturb_counts.unsqueeze(1)
-        use_original = torch.where(curve_indices.unsqueeze(1) == 1, relevant, ~relevant)
-        perturbed = torch.where(
-            use_original.unsqueeze(1),
-            input_tensor.flatten(2)[sample_indices],
-            baseline.flatten(2)[sample_indices],
-        ).reshape((-1, *input_tensor.shape[1:]))
-        scores = _get_scores(self.cam_extractor, self.logits_fn, perturbed)
-        return scores.gather(1, target_indices[sample_indices].unsqueeze(1)).squeeze(1)
-
     def _compute_curves(
         self,
         input_tensor: torch.Tensor,
@@ -306,13 +285,12 @@ class DeletionInsertionMetric:
         target_indices: torch.Tensor,
         original_scores: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        num_samples = input_tensor.shape[0]
         num_positions = ranks.shape[1]
         step_size = (num_positions + self.steps - 1) // self.steps
         counts = [*range(0, num_positions, step_size), num_positions]
         fractions = torch.tensor(counts, device=original_scores.device, dtype=torch.float32).div_(num_positions)
-        deletion = original_scores.new_empty((num_samples, len(counts)))
-        insertion = original_scores.new_empty((num_samples, len(counts)))
+        deletion = original_scores.new_empty((input_tensor.shape[0], len(counts)))
+        insertion = original_scores.new_empty((input_tensor.shape[0], len(counts)))
         deletion[:, 0] = original_scores
         insertion[:, -1] = original_scores
 
@@ -321,14 +299,31 @@ class DeletionInsertionMetric:
         ]
         jobs = [
             (sample_idx, curve_idx, point_idx, count)
-            for sample_idx in range(num_samples)
+            for sample_idx in range(input_tensor.shape[0])
             for curve_idx, point_idx, count in [(2, len(counts) - 1, num_positions), *interior_jobs]
         ]
 
         with self.cam_extractor._hooks_off(), torch.inference_mode():  # noqa: SLF001
             for start in range(0, len(jobs), self.batch_size):
                 chunk = jobs[start : start + self.batch_size]
-                selected_scores = self._score_perturbations(input_tensor, baseline, ranks, target_indices, chunk)
+                sample_indices = torch.tensor([job[0] for job in chunk], device=input_tensor.device)
+                perturb_counts = torch.tensor([job[3] for job in chunk], device=input_tensor.device)
+                relevant = ranks[sample_indices] < perturb_counts.unsqueeze(1)
+                use_original = torch.where(
+                    torch.tensor([job[1] for job in chunk], device=input_tensor.device).unsqueeze(1) == 1,
+                    relevant,
+                    ~relevant,
+                )
+                perturbed = torch.where(
+                    use_original.unsqueeze(1),
+                    input_tensor.flatten(2)[sample_indices],
+                    baseline.flatten(2)[sample_indices],
+                ).reshape((-1, *input_tensor.shape[1:]))
+                selected_scores = (
+                    _get_scores(self.cam_extractor, self.logits_fn, perturbed)
+                    .gather(1, target_indices[sample_indices].unsqueeze(1))
+                    .squeeze(1)
+                )
 
                 for score, job in zip(selected_scores, chunk, strict=True):
                     if job[1] == 0:

--- a/torchcam/metrics.py
+++ b/torchcam/metrics.py
@@ -3,8 +3,8 @@
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 
-from collections.abc import Callable
-from contextlib import AbstractContextManager
+from collections.abc import Callable, Iterator
+from contextlib import AbstractContextManager, contextmanager
 from typing import Any, Protocol, cast
 
 import torch
@@ -26,6 +26,68 @@ class _CAMExtractor(Protocol):
     def _hooks_off(self) -> AbstractContextManager[None]: ...
 
 
+@contextmanager
+def _model_eval(model: torch.nn.Module) -> Iterator[None]:
+    modes = [(module, module.training) for module in model.modules()]
+    try:
+        model.eval()
+        yield
+    finally:
+        for module, training in modes:
+            module.training = training
+
+
+def _get_scores(
+    cam_extractor: _CAMExtractor,
+    logits_fn: Callable[[torch.Tensor], torch.Tensor] | None,
+    input_tensor: torch.Tensor,
+) -> torch.Tensor:
+    logits = cam_extractor.model(input_tensor)
+    return cast(torch.Tensor, logits if logits_fn is None else logits_fn(logits))
+
+
+def _resolve_class_idx(scores: torch.Tensor, class_idx: int | list[int] | None) -> tuple[int | list[int], torch.Tensor]:
+    batch_size, num_classes = scores.shape
+    if class_idx is None:
+        target_indices = scores.argmax(dim=-1)
+        return target_indices.detach().cpu().tolist(), target_indices
+
+    if isinstance(class_idx, int):
+        if class_idx < 0 or class_idx >= num_classes:
+            raise ValueError("class_idx is out of range")
+        return class_idx, torch.full((batch_size,), class_idx, device=scores.device, dtype=torch.long)
+
+    if not isinstance(class_idx, list) or any(not isinstance(idx, int) or isinstance(idx, bool) for idx in class_idx):
+        raise TypeError("class_idx must be an integer, a list of integers, or None")
+    if len(class_idx) != batch_size:
+        raise ValueError("per-sample class_idx must match the batch size")
+    if any(idx < 0 or idx >= num_classes for idx in class_idx):
+        raise ValueError("class_idx is out of range")
+    return class_idx, torch.tensor(class_idx, device=scores.device)
+
+
+def _get_cam(
+    cam_extractor: _CAMExtractor,
+    scores: torch.Tensor,
+    class_idx: int | list[int] | None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    extractor_idx, target_indices = _resolve_class_idx(scores, class_idx)
+    cams = cam_extractor(extractor_idx, scores)
+    return cam_extractor.fuse_cams(cams), target_indices
+
+
+def _resize_cam(cam: torch.Tensor, spatial_shape: tuple[int, ...]) -> torch.Tensor:
+    interpolation_mode = {1: "linear", 2: "bilinear", 3: "trilinear"}.get(len(spatial_shape))
+    if interpolation_mode is None:
+        raise ValueError("only 1D, 2D, and 3D spatial inputs are supported")
+    return torch.nn.functional.interpolate(
+        cam.unsqueeze(1),
+        spatial_shape,
+        mode=interpolation_mode,
+        align_corners=False,
+    ).squeeze(1)
+
+
 class ClassificationMetric:
     r"""Implements Average Drop and Increase in Confidence from ["Grad-CAM++: Improved Visual Explanations for Deep
     Convolutional Networks."](https://arxiv.org/pdf/1710.11063.pdf).
@@ -33,7 +95,8 @@ class ClassificationMetric:
     The raw aggregated metric is computed as follows:
 
     $$
-    \forall N, H, W \in \mathbb{N}, \forall X \in \mathbb{R}^{N \times 3 \times H \times W},
+    \forall N, C, S_1, \ldots, S_d \in \mathbb{N},
+    \forall X \in \mathbb{R}^{N \times C \times S_1 \times \cdots \times S_d},
     \forall m \in \mathcal{M}, \forall c \in \mathcal{C}, \\
     AvgDrop_{m, c}(X) = \frac{1}{N} \sum\limits_{i=1}^N f_{m, c}(X_i) \\
     IncrConf_{m, c}(X) = \frac{1}{N} \sum\limits_{i=1}^N g_{m, c}(X_i)
@@ -82,14 +145,10 @@ class ClassificationMetric:
         self.logits_fn = logits_fn
         self.reset()
 
-    def _get_probs(self, input_tensor: torch.Tensor) -> torch.Tensor:
-        logits = self.cam_extractor.model(input_tensor)
-        return cast(torch.Tensor, logits if self.logits_fn is None else self.logits_fn(logits))
-
     def update(
         self,
         input_tensor: torch.Tensor,
-        class_idx: int | None = None,
+        class_idx: int | list[int] | None = None,
     ) -> None:
         """Update the state of the metric with new predictions.
 
@@ -97,46 +156,30 @@ class ClassificationMetric:
             input_tensor: preprocessed input tensor for the model
             class_idx: class index to focus on (default: index of the top predicted class for each sample)
         """
-        self.cam_extractor.model.eval()
-        probs = self._get_probs(input_tensor)
-        # Take the top preds for the cam
-        if isinstance(class_idx, int):
-            cams = self.cam_extractor(class_idx, probs)
-            cam = self.cam_extractor.fuse_cams(cams)
-            probs = probs[:, class_idx]
-        else:
-            preds = probs.argmax(dim=-1)
-            cams = self.cam_extractor(preds.cpu().numpy().tolist(), probs)
-            cam = self.cam_extractor.fuse_cams(cams)
-            probs = probs.gather(1, preds.unsqueeze(1)).squeeze(1)
-        with self.cam_extractor._hooks_off():  # noqa: SLF001
-            # Safeguard: skip NaNs
+        with _model_eval(self.cam_extractor.model):
+            scores = _get_scores(self.cam_extractor, self.logits_fn, input_tensor)
+            cam, target_indices = _get_cam(self.cam_extractor, scores, class_idx)
             discard = torch.isnan(cam).reshape(input_tensor.shape[0], -1).any(dim=-1)
-            cam = cam[~discard, ...]
-            probs = probs[~discard]
-            if class_idx is None:
-                preds = preds[~discard]
-            input_tensor = input_tensor[~discard]
-            # Resize the CAM
-            cam = torch.nn.functional.interpolate(cam.unsqueeze(1), input_tensor.shape[-2:], mode="bilinear")
-            # Create the explanation map & get the new probs
-            with torch.inference_mode():
-                masked_probs = self._get_probs(cam * input_tensor)
-            masked_probs = (
-                masked_probs[:, class_idx]
-                if isinstance(class_idx, int)
-                else masked_probs.gather(1, preds.unsqueeze(1)).squeeze(1)
-            )
-            # Drop (avoid division by zero)
-            drop = torch.relu(probs - masked_probs).div(probs + 1e-7)
+            nan_count = discard.sum().item()
+            if discard.all():
+                self.nan_count += nan_count
+                return
 
-            # Increase
-            increase = probs < masked_probs
+            cam = _resize_cam(cam[~discard], tuple(input_tensor.shape[2:]))
+            scores = scores[~discard].gather(1, target_indices[~discard].unsqueeze(1)).squeeze(1)
+            target_indices = target_indices[~discard]
+            valid_input = input_tensor[~discard]
+
+            with self.cam_extractor._hooks_off(), torch.inference_mode():  # noqa: SLF001
+                masked_scores = _get_scores(self.cam_extractor, self.logits_fn, cam.unsqueeze(1) * valid_input)
+            masked_scores = masked_scores.gather(1, target_indices.unsqueeze(1)).squeeze(1)
+            drop = torch.relu(scores - masked_scores).div(scores + 1e-7)
+            increase = scores < masked_scores
 
         self.drop += drop.sum().item()
         self.increase += increase.sum().item()
         self.total += cam.shape[0]
-        self.nan_count += discard.sum().item()
+        self.nan_count += nan_count
 
     def summary(self) -> dict[str, float]:
         """Computes the aggregated metrics.
@@ -159,5 +202,207 @@ class ClassificationMetric:
         """Reset the state of the metric."""
         self.drop = 0.0
         self.increase = 0.0
+        self.total = 0
+        self.nan_count = 0
+
+
+class DeletionInsertionMetric:
+    r"""Implements deletion and insertion faithfulness metrics from ["RISE: Randomized Input Sampling for
+    Explanation of Black-box Models."](https://arxiv.org/abs/1806.07421).
+
+    Spatial positions are ranked from the highest to the lowest CAM value. Deletion progressively replaces the
+    highest-ranked positions with a baseline, while insertion progressively restores them from the original input.
+    The mask is shared across channels. Both scores are areas under the selected-class score curves, integrated
+    against the actual perturbed fraction with :func:`torch.trapezoid`.
+
+    Example:
+        ```python
+        from functools import partial
+        from torchcam.metrics import DeletionInsertionMetric
+        metric = DeletionInsertionMetric(cam_extractor, partial(torch.softmax, dim=-1))
+        metric.update(input_tensor)
+        metric.summary()
+        ```
+
+    Args:
+        cam_extractor: CAM extractor used to rank spatial positions
+        logits_fn: optional function applied to the model output before selecting class scores
+        steps: maximum number of perturbation intervals
+        baseline: baseline tensor, callable producing one, or ``None`` to use zeros
+        batch_size: maximum number of perturbed inputs scored per model forward
+
+    Raises:
+        TypeError: if an argument has an invalid type
+        ValueError: if ``steps`` or ``batch_size`` is not positive
+    """
+
+    def __init__(
+        self,
+        cam_extractor: _CAMExtractor,
+        logits_fn: Callable[[torch.Tensor], torch.Tensor] | None = None,
+        *,
+        steps: int = 20,
+        baseline: torch.Tensor | Callable[[torch.Tensor], torch.Tensor] | None = None,
+        batch_size: int = 32,
+    ) -> None:
+        if not isinstance(steps, int) or isinstance(steps, bool):
+            raise TypeError("steps must be an integer")
+        if steps <= 0:
+            raise ValueError("steps must be positive")
+        if not isinstance(batch_size, int) or isinstance(batch_size, bool):
+            raise TypeError("batch_size must be an integer")
+        if batch_size <= 0:
+            raise ValueError("batch_size must be positive")
+        if baseline is not None and not isinstance(baseline, torch.Tensor) and not callable(baseline):
+            raise TypeError("baseline must be a tensor, a callable, or None")
+
+        self.cam_extractor = cam_extractor
+        self.logits_fn = logits_fn
+        self.steps = steps
+        self.baseline = baseline
+        self.batch_size = batch_size
+        self.reset()
+
+    def _get_baseline(self, input_tensor: torch.Tensor) -> torch.Tensor:
+        if self.baseline is None:
+            return torch.zeros_like(input_tensor)
+        if isinstance(self.baseline, torch.Tensor):
+            baseline = self.baseline
+        else:
+            baseline = self.baseline(input_tensor)
+            if not isinstance(baseline, torch.Tensor):
+                raise TypeError("baseline callable must return a tensor")
+        try:
+            return torch.broadcast_to(baseline.to(input_tensor), input_tensor.shape)
+        except RuntimeError as exc:
+            raise ValueError("baseline must be broadcastable to the input shape") from exc
+
+    def _score_perturbations(
+        self,
+        input_tensor: torch.Tensor,
+        baseline: torch.Tensor,
+        ranks: torch.Tensor,
+        target_indices: torch.Tensor,
+        jobs: list[tuple[int, int, int, int]],
+    ) -> torch.Tensor:
+        sample_indices = torch.tensor([job[0] for job in jobs], device=input_tensor.device)
+        curve_indices = torch.tensor([job[1] for job in jobs], device=input_tensor.device)
+        perturb_counts = torch.tensor([job[3] for job in jobs], device=input_tensor.device)
+        relevant = ranks[sample_indices] < perturb_counts.unsqueeze(1)
+        use_original = torch.where(curve_indices.unsqueeze(1) == 1, relevant, ~relevant)
+        perturbed = torch.where(
+            use_original.unsqueeze(1),
+            input_tensor.flatten(2)[sample_indices],
+            baseline.flatten(2)[sample_indices],
+        ).reshape((-1, *input_tensor.shape[1:]))
+        scores = _get_scores(self.cam_extractor, self.logits_fn, perturbed)
+        return scores.gather(1, target_indices[sample_indices].unsqueeze(1)).squeeze(1)
+
+    def _compute_curves(
+        self,
+        input_tensor: torch.Tensor,
+        baseline: torch.Tensor,
+        ranks: torch.Tensor,
+        target_indices: torch.Tensor,
+        original_scores: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        num_samples = input_tensor.shape[0]
+        num_positions = ranks.shape[1]
+        step_size = (num_positions + self.steps - 1) // self.steps
+        counts = [*range(0, num_positions, step_size), num_positions]
+        fractions = torch.tensor(counts, device=original_scores.device, dtype=torch.float32).div_(num_positions)
+        deletion = original_scores.new_empty((num_samples, len(counts)))
+        insertion = original_scores.new_empty((num_samples, len(counts)))
+        deletion[:, 0] = original_scores
+        insertion[:, -1] = original_scores
+
+        interior_jobs = [
+            (curve_idx, point_idx, count) for point_idx, count in enumerate(counts[1:-1], 1) for curve_idx in range(2)
+        ]
+        jobs = [
+            (sample_idx, curve_idx, point_idx, count)
+            for sample_idx in range(num_samples)
+            for curve_idx, point_idx, count in [(2, len(counts) - 1, num_positions), *interior_jobs]
+        ]
+
+        with self.cam_extractor._hooks_off(), torch.inference_mode():  # noqa: SLF001
+            for start in range(0, len(jobs), self.batch_size):
+                chunk = jobs[start : start + self.batch_size]
+                selected_scores = self._score_perturbations(input_tensor, baseline, ranks, target_indices, chunk)
+
+                for score, job in zip(selected_scores, chunk, strict=True):
+                    if job[1] == 0:
+                        deletion[job[0], job[2]] = score
+                    elif job[1] == 1:
+                        insertion[job[0], job[2]] = score
+                    else:
+                        deletion[job[0], job[2]] = score
+                        insertion[job[0], 0] = score
+
+        return fractions, deletion, insertion
+
+    def update(
+        self,
+        input_tensor: torch.Tensor,
+        class_idx: int | list[int] | None = None,
+    ) -> None:
+        """Update the metric with a batch of inputs.
+
+        Args:
+            input_tensor: preprocessed model input
+            class_idx: shared class index, one class index per sample, or ``None`` to use original top predictions
+        """
+        with _model_eval(self.cam_extractor.model):
+            scores = _get_scores(self.cam_extractor, self.logits_fn, input_tensor)
+            cam, target_indices = _get_cam(self.cam_extractor, scores, class_idx)
+            discard = torch.isnan(cam).reshape(input_tensor.shape[0], -1).any(dim=-1)
+            nan_count = discard.sum().item()
+            if discard.all():
+                self.nan_count += nan_count
+                return
+
+            with torch.no_grad():
+                baseline = self._get_baseline(input_tensor)[~discard]
+            valid_input = input_tensor[~discard]
+            cam = _resize_cam(cam[~discard], tuple(input_tensor.shape[2:]))
+            target_indices = target_indices[~discard]
+            original_scores = scores[~discard].gather(1, target_indices.unsqueeze(1)).squeeze(1).detach()
+            order = torch.argsort(cam.flatten(1), dim=1, descending=True, stable=True)
+            ranks = torch.argsort(order, dim=1)
+            fractions, deletion, insertion = self._compute_curves(
+                valid_input,
+                baseline,
+                ranks,
+                target_indices,
+                original_scores,
+            )
+            deletion_auc = torch.trapezoid(deletion, fractions, dim=1)
+            insertion_auc = torch.trapezoid(insertion, fractions, dim=1)
+
+        self.deletion += deletion_auc.sum().item()
+        self.insertion += insertion_auc.sum().item()
+        self.total += valid_input.shape[0]
+        self.nan_count += nan_count
+
+    def summary(self) -> dict[str, float]:
+        """Compute the mean deletion and insertion AUCs.
+
+        Returns:
+            deletion and insertion AUCs averaged over non-NaN samples
+
+        Raises:
+            AssertionError: if the metric has not been updated with a valid CAM
+        """
+        if self.total == 0:
+            raise AssertionError("you need to update the metric before getting the summary")
+        return {
+            "deletion_auc": self.deletion / self.total,
+            "insertion_auc": self.insertion / self.total,
+        }
+
+    def reset(self) -> None:
+        """Reset the accumulated metric state."""
+        self.deletion = 0.0
+        self.insertion = 0.0
         self.total = 0
         self.nan_count = 0

--- a/torchcam/metrics.py
+++ b/torchcam/metrics.py
@@ -140,7 +140,6 @@ class ClassificationMetric:
         cam_extractor: _CAMExtractor,
         logits_fn: Callable[[torch.Tensor], torch.Tensor] | None = None,
     ) -> None:
-        # This is a typa, I don't know how to rites
         self.cam_extractor = cam_extractor
         self.logits_fn = logits_fn
         self.reset()
@@ -297,6 +296,7 @@ class DeletionInsertionMetric:
         interior_jobs = [
             (curve_idx, point_idx, count) for point_idx, count in enumerate(counts[1:-1], 1) for curve_idx in range(2)
         ]
+        # Curve 2 is the all-baseline input shared by deletion's final point and insertion's first.
         jobs = [
             (sample_idx, curve_idx, point_idx, count)
             for sample_idx in range(input_tensor.shape[0])


### PR DESCRIPTION
## Summary

This PR adds deletion and insertion faithfulness evaluation to TorchCAM through a new stateful `DeletionInsertionMetric`, following the existing `update()` / `summary()` / `reset()` metric pattern.

It also makes focused, backward-compatible corrections to `ClassificationMetric` and adds an opt-in benchmark path. No dependencies, release metadata, README files, demos, or default benchmark behavior are changed.

## Metric protocol

The implementation follows the deletion/insertion protocol introduced in [RISE](https://arxiv.org/abs/1806.07421):

1. Generate each sample's CAM with gradients enabled.
2. Fuse multi-layer CAMs through the extractor's existing `fuse_cams` protocol.
3. Resize the CAM to `input_tensor.shape[2:]` and rank spatial positions from highest to lowest relevance.
4. For deletion, progressively replace ranked positions with the baseline.
5. For insertion, progressively restore ranked positions from the original input.
6. Apply each spatial mask identically across input channels.
7. Include the unperturbed and fully perturbed endpoints.
8. Integrate each sample's selected-class curve against its actual perturbed fractions with `torch.trapezoid`, then average valid samples.

`steps` is the maximum interval count. Each interval changes `ceil(P / steps)` of the `P` spatial positions, with a shorter final interval when necessary.

Lower deletion AUC and higher insertion AUC indicate stronger perturbation faithfulness.

## API

```python
metric = DeletionInsertionMetric(
    cam_extractor,
    logits_fn=None,
    steps=20,
    baseline=None,
    batch_size=32,
)

metric.update(input_tensor, class_idx=None)
metric.summary()
# {
#     "deletion_auc": ...,
#     "insertion_auc": ...,
# }
```

- `class_idx` accepts a shared integer, one integer per sample, or `None` to keep each sample's original predicted class fixed across both curves.
- `baseline=None` uses `zeros_like(input_tensor)`.
- A broadcastable tensor or a callable invoked once per update can be supplied instead.
- Perturbed forwards run under `torch.inference_mode()` with CAM hooks suspended.
- `batch_size` bounds temporary perturbation memory without changing numerical results.
- NaN CAM samples are skipped atomically and exposed through `nan_count`.

## Compatibility

The implementation supports:

- ordinary and wrapped extractors through TorchCAM's existing private structural protocol;
- multi-layer CAM fusion;
- 2D and 3D spatial inputs;
- preservation of input tensors, baseline tensors, device, and dtype;
- exact restoration of mixed model training/evaluation flags and hook state after both successful and exceptional exits.

`ClassificationMetric` keeps its existing summary keys and numerical definitions while gaining per-sample class indices, dimension-aware CAM resizing, all-NaN handling, and exception-safe model-state restoration.

## Benchmark integration

`scripts/eval_perf.py` gains three opt-in flags:

- `--deletion-insertion`
- `--di-steps`
- `--di-batch-size`

Without `--deletion-insertion`, existing behavior and output are unchanged.

## Interpretation and runtime

Deletion/insertion evaluate sensitivity of the model's selected-class score to a CAM-ordered perturbation. They do not prove localization quality, human interpretability, or causal correctness.

Results are baseline-sensitive. The default zero baseline represents the dataset mean only for inputs normalized so that the mean maps to zero. The original RISE experiments used constant deletion values and a blurred insertion substrate; this implementation deliberately uses one configured baseline for both curves. Reproducing those substrates requires separate runs and comparison of the corresponding AUCs.

By default AUCs integrate raw model outputs. Passing softmax produces probability curves; raw-logit and probability AUCs should not be compared directly.

With `S` effective intervals, each valid sample requires `2S - 1` additional perturbed evaluations beyond the original CAM-producing forward and any backward pass required by the extractor. Smaller scoring batches reduce peak memory but do not reduce total work.

## Empirical sanity check

The metric was run on a deterministic balanced subset of 200 Imagenette validation images (20 per class) using pretrained ResNet-18, 224x224 ImageNet preprocessing, each model-predicted class held fixed, softmax scores, a zero baseline, 20 perturbation intervals, and MPS execution.

| CAM method | Target layer(s) | Deletion AUC ↓ | Insertion AUC ↑ | Skipped |
| --- | --- | ---: | ---: | ---: |
| GradCAM | `layer4` | 0.1422 | **0.5030** | 0 |
| GradCAM++ | `layer4` | 0.1389 | 0.4918 | 0 |
| Smooth GradCAM++ | `layer4` | 0.1443 | 0.4772 | 0 |
| XGradCAM | `layer4` | 0.1422 | 0.5029 | 0 |
| LayerCAM | `layer4` | 0.1397 | 0.4807 | 0 |
| FinerCAM | `layer4` | 0.1432 | 0.5014 | 0 |
| RefineCAM | `layer2,layer3,layer4` | **0.0968** | 0.4497 | 0 |
| Seeded random ranking | 7x7 control | 0.2176 | 0.2138 | 0 |
| Inverted GradCAM | `layer4` control | 0.5028 | 0.1422 | 0 |

The mean original selected-class probability was 0.7416; the mean probability for the same class on the zero baseline was 0.0008.

Every real CAM ranked better than the seeded random control in both directions. Inverting GradCAM almost exchanged its deletion and insertion AUCs, which confirms that the implementation responds to ranking direction rather than merely the amount of perturbation. RefineCAM had the strongest deletion score but not the strongest insertion score, so the two AUCs expose a real trade-off rather than yielding one universal winner.

This is a protocol sanity check, not a leaderboard result: it uses 200 of 3,925 validation images, predicted rather than ground-truth targets, and the normalized-mean zero baseline. Method ordering may change with the model, layer selection, samples, scoring transform, and baseline.

## Validation

- `rtk uv run --python 3.12 --extra test pytest -q tests/test_metrics.py`: 39 passed, 1 skipped
- `rtk uv run --python 3.12 --extra test pytest`: 160 passed, 2 skipped
- `torchcam/metrics.py`: 169/169 executable lines covered locally
- `rtk make quality`: passed
- `DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/opt/cairo/lib:/opt/homebrew/lib rtk uv run --python 3.12 --extra docs mkdocs build --strict -f docs/mkdocs.yml`: passed
- `scripts/eval_perf.py --help`: all three opt-in flags present
- `git diff --check`: passed
- Metrics reference inspected at desktop and 375px widths without page or formula overflow
- Four independent adversarial reviews completed with no blocking correctness findings
- GitHub Actions checks passed on current head `9654e8c`
