### PR TITLE
feat(explain): add agent-native prediction debugging

### DIFF
--- a/.agents/skills/torchcam-debug-prediction/SKILL.md
+++ b/.agents/skills/torchcam-debug-prediction/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: torchcam-debug-prediction
+description: Debug one surprising 2D image-classification prediction in an existing PyTorch repository with TorchCAM. Use when an owner asks for predicted-versus-expected CAM evidence, a saved explanation bundle, GradCAM on a CNN, or LeGrad on a supported Vision Transformer. Reuse the repository's trusted model loader, checkpoint, class mapping, and preprocessing instead of inventing replacements.
+compatibility: Requires local Python execution, PyTorch, Pillow, and torchcam>=0.5.0.
+metadata:
+  author: frgfm
+  version: "1.0"
+---
+
+# Debug one prediction with TorchCAM
+
+Produce reproducible visual evidence for one surprising classifier prediction. CAMs show class-associated activation, not why the model decided, causal influence, correctness, or localization quality.
+
+## 1. Discover the repository's inference path
+
+Find and reuse the code that already defines:
+
+- the model architecture and trusted checkpoint loader;
+- evaluation preprocessing, including resize, crop, normalization, and color conversion;
+- the ordered class-name mapping;
+- the original image before normalization.
+
+Search the repository before writing code. Prefer its test or inference entry point over reconstructing the model. Load only checkpoints already trusted by the owner; TorchCAM does not load checkpoints or preprocessing.
+
+Confirm the model returns one logits tensor shaped `(1, num_classes)`. If it returns a tuple or dictionary, wrap it in a small `nn.Module` that selects the logits tensor without changing inference.
+
+## 2. Choose the extractor
+
+- CNN: start with the default `GradCAM`. Let TorchCAM resolve the last spatial layer. If resolution fails or the repository has a known semantic feature layer, pass that exact module or name as `target_layer`.
+- Torchvision Vision Transformer: use `LeGrad` and explicit transformer blocks, usually the last four: `list(model.encoder.layers)[-4:]`.
+- Other ViTs: use `LeGrad` only when the blocks expose supported batch-first `nn.MultiheadAttention`. Pass the repository-specific `score_projection`, `prefix_tokens`, or `grid_shape` through `method_kwargs` when required.
+- Existing reshape-based CAM setup: preserve its explicit target layer and pass `reshape_transform` through `method_kwargs`.
+
+Do not add an architecture registry or guess a ViT configuration.
+
+## 3. Run one explanation
+
+Call `model.eval()`. Keep the call outside `torch.inference_mode()` because CAM extraction needs gradients. The input must be a batch of one shaped `(1, C, H, W)`.
+
+```python
+from torchcam.explain import explain
+
+result = explain(
+    model,
+    input_tensor,
+    expected_class_idx=expected_idx,
+    class_names=class_names,
+    target_layer=target_layer,  # omit for automatic CNN resolution
+)
+bundle = result.save("torchcam-explanation", image=original_image, alpha=0.5)
+```
+
+For a ViT, also pass `method=LeGrad` and the explicit blocks. Use a new output directory; `save` refuses to overwrite an existing one.
+
+## 4. Validate the evidence bundle
+
+Treat `manifest.json` as the completion marker. Before reporting success:
+
+1. Parse it and require `schema_version == 1`.
+2. Read artifacts from `manifest["classes"][str(class_idx)]["artifacts"]`. Resolve every relative `map`, `heatmap`, and `overlay` path under the bundle directory and require each file to exist. Prediction and expected entries contain class references; logits and probabilities live in the corresponding class entry.
+3. Load each `.npy` map with `allow_pickle=False`; require a finite two-dimensional `float32` array.
+4. Open every overlay and require its dimensions to match `manifest.json`'s `image_size`.
+5. Confirm the prediction and optional expected class indices match the repository's class ordering.
+
+No manifest means the bundle is incomplete, even if some images exist.
+
+## 5. Report to the owner
+
+Return:
+
+- predicted class and the owner's expected class, with indices and model scores/probabilities from the manifest;
+- the resolved method and target layers;
+- the bundle path and the most useful overlay paths;
+- any compatibility boundary or uncertainty encountered.
+
+Use language such as “the GradCAM map highlights…” or “activation differs between…”. Do not claim the map proves causation, model correctness, object localization, bias, safety, or compliance.
+
+Check each map's range before describing it. If it is constant or all zero, call it a blank map and do not claim it highlights a region or shows positive class-associated activation; a blank CAM is not proof that a feature is absent.
+
+If extraction fails, use the TorchCAM prediction-debugging guide and troubleshooting page before changing repository model code.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@
 
 Simple way to leverage the class-specific activation of convolutional layers in PyTorch.
 
+Debugging one surprising classifier result? Use the [predicted-versus-expected agent workflow](https://frgfm.github.io/torch-cam/getting-started/debug-prediction/), give a compatible agent the [portable skill](https://github.com/frgfm/torch-cam/blob/main/.agents/skills/torchcam-debug-prediction/SKILL.md), or start from [`llms.txt`](https://frgfm.github.io/torch-cam/llms.txt).
+
 <p align="center">
     <a alt="cam_examples">
         <img src="https://github.com/frgfm/torch-cam/releases/download/v0.3.1/example.png" /></a>

--- a/docs/docs/getting-started/debug-prediction.md
+++ b/docs/docs/getting-started/debug-prediction.md
@@ -1,0 +1,96 @@
+# Debug one prediction with an AI agent
+
+Use `torchcam.explain.explain` when a classifier's top prediction differs from the class you expected. It runs the model, extracts normalized class activation maps for the predicted and optional expected class, and saves a machine-readable evidence bundle.
+
+TorchCAM deliberately does not load models, checkpoints, labels, or preprocessing. Reuse those trusted pieces from the owner's repository so the explanation describes the same inference path.
+
+## CNN example
+
+This complete example uses automatic CNN target-layer resolution and writes predicted-versus-expected evidence:
+
+```python
+from PIL import Image
+from torchvision.models import ResNet18_Weights, resnet18
+
+from torchcam.explain import explain
+
+image = Image.open("surprising.jpg").convert("RGB")
+weights = ResNet18_Weights.DEFAULT
+model = resnet18(weights=weights).eval()
+class_names = weights.meta["categories"]
+input_tensor = weights.transforms()(image).unsqueeze(0)
+
+result = explain(
+    model,
+    input_tensor,
+    expected_class_idx=207,  # repository class index, for example "golden retriever"
+    class_names=class_names,
+)
+result.save("torchcam-explanation", image, alpha=0.5)
+```
+
+The default method is [`GradCAM`][torchcam.methods.GradCAM]. If automatic target resolution is unsuitable for a custom CNN, pass the repository's feature layer, such as `target_layer="backbone.layer4"`.
+
+## Vision Transformer example
+
+ViTs require an explicit method and target blocks. Torchvision `VisionTransformer` is supported directly by [`LeGrad`][torchcam.methods.LeGrad]:
+
+```python
+from PIL import Image
+from torchvision.models import ViT_B_16_Weights, vit_b_16
+
+from torchcam.explain import explain
+from torchcam.methods import LeGrad
+
+image = Image.open("surprising.jpg").convert("RGB")
+weights = ViT_B_16_Weights.DEFAULT
+model = vit_b_16(weights=weights).eval()
+input_tensor = weights.transforms()(image).unsqueeze(0)
+
+result = explain(
+    model,
+    input_tensor,
+    expected_class_idx=207,
+    class_names=weights.meta["categories"],
+    method=LeGrad,
+    target_layer=list(model.encoder.layers)[-4:],
+)
+result.save("torchcam-vit-explanation", image)
+```
+
+For another supported ViT, pass its `score_projection`, `prefix_tokens`, or `grid_shape` through `method_kwargs`. Do not rely on automatic architecture detection; see [advanced usage](advanced-usage.md#legrad-for-torchvision-vision-transformers) for compatibility details.
+
+## Ask a coding agent
+
+Agents that support portable [Agent Skills](https://agentskills.io/specification) can progressively load the repository's [`torchcam-debug-prediction` skill](https://github.com/frgfm/torch-cam/tree/main/.agents/skills/torchcam-debug-prediction). See [OpenAI's Skills documentation](https://developers.openai.com/codex/skills) for one supported client. [`llms.txt`](https://llmstxt.org/) helps agents discover the guide and API; it is not the execution contract.
+
+Copy this prompt into an agent running inside the repository that owns the model:
+
+> Debug the surprising prediction for `path/to/image.jpg` with TorchCAM. Reuse this repository's real model loader, trusted checkpoint, evaluation preprocessing, and class mapping. Compare the predicted class with expected class `<name or index>`, save a complete schema-v1 explanation bundle to a new directory, validate every manifest artifact, and report the evidence without causal or correctness claims. Do not replace the repository's inference path.
+
+## Result contract
+
+`explain` returns a frozen [`PredictionExplanation`][torchcam.explain.PredictionExplanation] with:
+
+- detached CPU `float32` logits;
+- predicted and optional expected class indices;
+- normalized two-dimensional CPU `float32` CAMs in `result.cams[class_idx]`;
+- method, resolved target layers, model identity, input shape, class names, and runtime versions.
+
+A distinct expected class gets a fresh model forward. If expected and predicted indices match, TorchCAM reuses the predicted map.
+
+`result.save(directory, image, alpha=0.5)` creates a new directory and never overwrites one. For each class and returned map it writes:
+
+- `class-<class_idx>-layer-<layer_idx>.npy`: the finite `float32` CAM;
+- `class-<class_idx>-layer-<layer_idx>-heatmap.png`: an 8-bit grayscale heatmap;
+- `class-<class_idx>-layer-<layer_idx>-overlay.png`: a full-size overlay matching the source image.
+
+It writes `manifest.json` last. Its presence marks a complete bundle. Schema version 1 contains `prediction`, optional `expected`, per-class logits/probabilities and relative artifact paths, the contributing `target_layers` for each map, `method`, all resolved target layers, `model`, `input_shape`, `versions`, `[width, height]` `image_size`, and `alpha`. A directory with artifacts but no manifest is incomplete.
+
+## Boundaries and troubleshooting
+
+This workflow supports one 2D image and a classifier that returns finite logits shaped `(1, num_classes)`. The model must already be in evaluation mode and the input tensor must use a floating-point dtype. Batched inputs, 3D/video explanations, tuple/dictionary outputs, inference mode, non-finite logits, and non-finite maps are rejected. Wrap tuple/dictionary models so their forward returns the logits tensor.
+
+CAMs are diagnostic activation evidence. They are not causal explanations, localization scores, proofs of correctness, or compliance evidence.
+
+For layer selection, reshape transforms, and custom ViTs, read [advanced usage](advanced-usage.md). For hook, gradient, blank-map, and NaN failures, read [troubleshooting](troubleshooting.md).

--- a/docs/docs/reference/explain.md
+++ b/docs/docs/reference/explain.md
@@ -1,0 +1,3 @@
+# Prediction explanations
+
+::: torchcam.explain

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -72,13 +72,19 @@ plugins:
   llmstxt:
     full_output: llms-full.txt
     autoclean: true
+    markdown_description: >-
+      Start with [Debug one prediction with an AI agent](https://frgfm.github.io/torch-cam/getting-started/debug-prediction/)
+      and the canonical [portable TorchCAM skill](https://github.com/frgfm/torch-cam/blob/main/.agents/skills/torchcam-debug-prediction/SKILL.md).
+      The skill carries execution instructions; this file is a discovery aid.
     sections:
       Getting started:
         - getting-started/installation.md
         - getting-started/notebooks.md
+        - getting-started/debug-prediction.md
         - getting-started/advanced-usage.md
         - getting-started/troubleshooting.md
       Package Reference:
+        - reference/explain.md
         - reference/methods.md
         - reference/metrics.md
         - reference/utils.md
@@ -173,9 +179,11 @@ nav:
   - Getting started:
     - getting-started/installation.md
     - getting-started/notebooks.md
+    - Debug one prediction: getting-started/debug-prediction.md
     - getting-started/advanced-usage.md
     - getting-started/troubleshooting.md
   - Package Reference:
+    - Prediction explanations: reference/explain.md
     - Interpretability methods: reference/methods.md
     - Evaluation metrics: reference/metrics.md
     - Utilities: reference/utils.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "torchcam"
-version = "0.4.2.dev0"
+version = "0.5.0.dev0"
 description = "Class activation maps for your PyTorch CNN models"
 authors = [
     {name = "François-Guillaume Fernandez", email = "fg-feedback@protonmail.com"}

--- a/tests/test_explain.py
+++ b/tests/test_explain.py
@@ -217,12 +217,16 @@ def test_save_writes_complete_deterministic_bundle(tmp_path):
 def test_save_writes_manifest_only_after_artifacts(tmp_path, monkeypatch):
     model = _TinyCNN().eval()
     result = explain(model, torch.randn(1, 3, 8, 8), target_layer="features.1")
+    output_dir = tmp_path / "incomplete"
+    image = Image.new("RGB", (8, 8))
 
     def fail_overlay(*_args, **_kwargs):
         raise RuntimeError("render failed")
 
-    monkeypatch.setattr(explain_module, "overlay_mask", fail_overlay)
-    with pytest.raises(RuntimeError, match="render failed"):
-        result.save(tmp_path / "incomplete", Image.new("RGB", (8, 8)))
+    with monkeypatch.context() as patch:
+        patch.setattr(explain_module, "overlay_mask", fail_overlay)
+        with pytest.raises(RuntimeError, match="render failed"):
+            result.save(output_dir, image)
 
-    assert not (tmp_path / "incomplete" / "manifest.json").exists()
+    assert not output_dir.exists()
+    assert result.save(output_dir, image) == output_dir

--- a/tests/test_explain.py
+++ b/tests/test_explain.py
@@ -1,5 +1,6 @@
 import importlib
 import json
+from typing import Any, cast
 
 import numpy as np
 import pytest
@@ -116,23 +117,46 @@ def test_explain_supports_torchvision_vit_with_legrad(tmp_path):
     assert artifact["target_layers"] == list(result.target_layers)
 
 
-def test_explain_rejects_invalid_inputs_and_outputs(monkeypatch):
+def test_explain_rejects_invalid_requests():
     model = _TinyCNN()
     input_tensor = torch.randn(1, 3, 8, 8)
+    with pytest.raises(ValueError, match="model output must have shape"):
+        explain_module._validate_logits(torch.zeros(3))
     with pytest.raises(ValueError, match="no CAMs"):
         explain_module._prepare_maps([])
+    with pytest.raises(ValueError, match="CAMs must have shape"):
+        explain_module._prepare_maps([torch.zeros(2, 2)])
+    with pytest.raises(TypeError, match="Module"):
+        explain(cast(Any, None), input_tensor)
     with pytest.raises(ValueError, match="evaluation mode"):
         explain(model, input_tensor, target_layer="features.1")
 
     model.eval()
+    with pytest.raises(TypeError, match="Tensor"):
+        explain(model, cast(Any, None), target_layer="features.1")
     with pytest.raises(ValueError, match="shape"):
         explain(model, torch.randn(2, 3, 8, 8), target_layer="features.1")
     with pytest.raises(ValueError, match="floating-point"):
         explain(model, torch.zeros(1, 3, 8, 8, dtype=torch.uint8), target_layer="features.1")
+    with pytest.raises(TypeError, match="integer or None"):
+        explain(model, input_tensor, expected_class_idx=cast(Any, "0"), target_layer="features.1")
+    with pytest.raises(TypeError, match="extractor class"):
+        explain(model, input_tensor, method=cast(Any, nn.Module), target_layer="features.1")
+    with pytest.raises(TypeError, match="mapping"):
+        explain(model, input_tensor, method_kwargs=cast(Any, []), target_layer="features.1")
     with pytest.raises(ValueError, match="output range"):
         explain(model, input_tensor, expected_class_idx=3, target_layer="features.1")
     with pytest.raises(ValueError, match="class_names"):
         explain(model, input_tensor, class_names=["a"], target_layer="features.1")
+    with pytest.raises(TypeError, match="class name"):
+        explain(model, input_tensor, class_names=cast(Any, ["a", "b", 3]), target_layer="features.1")
+    with pytest.raises(ValueError, match="directly"):
+        explain(model, input_tensor, method_kwargs={"target_layer": "features.1"})
+
+
+def test_explain_rejects_invalid_outputs(monkeypatch):
+    model = _TinyCNN().eval()
+    input_tensor = torch.randn(1, 3, 8, 8)
     with pytest.raises(TypeError, match="tensor"):
         explain(_TupleModel().eval(), input_tensor, target_layer="features.1")
     with pytest.raises(ValueError, match="non-finite logits"):
@@ -143,9 +167,26 @@ def test_explain_rejects_invalid_inputs_and_outputs(monkeypatch):
         maps[0][0, 0, 0] = float("nan")
         return prepare_maps(maps)
 
-    monkeypatch.setattr(explain_module, "_prepare_maps", inject_non_finite)
-    with pytest.raises(ValueError, match="non-finite"):
-        explain(model, input_tensor, target_layer="features.1")
+    with monkeypatch.context() as patch:
+        patch.setattr(explain_module, "_prepare_maps", inject_non_finite)
+        with pytest.raises(ValueError, match="non-finite"):
+            explain(model, input_tensor, target_layer="features.1")
+
+    predicted = int(model(input_tensor).argmax().item())
+    expected = (predicted + 1) % 3
+    original_forward = model.forward
+    forward_count = 0
+
+    def change_output_shape(tensor):
+        nonlocal forward_count
+        forward_count += 1
+        output = original_forward(tensor)
+        return output if forward_count == 1 else output[:, :-1]
+
+    with monkeypatch.context() as patch:
+        patch.setattr(model, "forward", change_output_shape)
+        with pytest.raises(ValueError, match="shape changed"):
+            explain(model, input_tensor, expected_class_idx=expected, target_layer="features.1")
 
     with torch.inference_mode(), pytest.raises(RuntimeError, match="inference_mode"):
         explain(model, input_tensor, target_layer="features.1")
@@ -182,6 +223,8 @@ def test_save_writes_complete_deterministic_bundle(tmp_path):
         target_layer="features.1",
     )
     image = Image.fromarray(np.zeros((13, 19, 3), dtype=np.uint8))
+    with pytest.raises(TypeError, match="PIL image"):
+        result.save(tmp_path / "bad-image", cast(Any, None))
     bundle = result.save(tmp_path / "bundle", image)
 
     expected_files = {"manifest.json"}

--- a/tests/test_explain.py
+++ b/tests/test_explain.py
@@ -1,0 +1,228 @@
+import importlib
+import json
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+from torch import nn
+from torchvision.models.vision_transformer import VisionTransformer
+
+from torchcam.explain import explain
+from torchcam.methods import LeGrad
+
+explain_module = importlib.import_module("torchcam.explain")
+
+
+class _TinyCNN(nn.Module):
+    def __init__(self, *, count_forwards=False):
+        super().__init__()
+        self.features = nn.Sequential(nn.Conv2d(3, 4, 3, padding=1), nn.ReLU())
+        self.pool = nn.AdaptiveAvgPool2d(1)
+        self.classifier = nn.Linear(4, 3)
+        self.count_forwards = count_forwards
+        self.forward_count = 0
+
+    def forward(self, input_tensor):
+        if self.count_forwards:
+            self.forward_count += 1
+        return self.classifier(self.pool(self.features(input_tensor)).flatten(1))
+
+
+class _TupleModel(_TinyCNN):
+    def forward(self, input_tensor):
+        output = super().forward(input_tensor)
+        return output, output
+
+
+class _NonFiniteModel(_TinyCNN):
+    def forward(self, input_tensor):
+        output = super().forward(input_tensor)
+        return output * torch.tensor(float("nan"), device=output.device)
+
+
+def _tiny_vit():
+    return VisionTransformer(
+        image_size=32,
+        patch_size=8,
+        num_layers=2,
+        num_heads=4,
+        hidden_dim=32,
+        mlp_dim=64,
+        num_classes=3,
+        dropout=0,
+        attention_dropout=0,
+    )
+
+
+def test_explain_predicted_class_with_automatic_cnn_target():
+    model = _TinyCNN().eval()
+    result = explain(model, torch.randn(1, 3, 8, 8), class_names=["a", "b", "c"])
+
+    assert result.logits.shape == (1, 3)
+    assert result.logits.device.type == "cpu"
+    assert result.logits.dtype == torch.float32
+    assert not result.logits.requires_grad
+    assert set(result.cams) == {result.predicted_class_idx}
+    assert result.cams[result.predicted_class_idx][0].shape == (8, 8)
+    assert result.cams[result.predicted_class_idx][0].dtype == torch.float32
+    assert result.target_layers == ("features",)
+    assert result.method == "GradCAM"
+    assert result.class_names == ("a", "b", "c")
+
+
+def test_explain_runs_fresh_forward_for_distinct_expected_class():
+    model = _TinyCNN(count_forwards=True).eval()
+    input_tensor = torch.randn(1, 3, 8, 8)
+    predicted = model(input_tensor).argmax().item()
+    expected = (predicted + 1) % 3
+    model.forward_count = 0
+
+    result = explain(model, input_tensor, expected_class_idx=expected, target_layer="features.1")
+
+    assert model.forward_count == 2
+    assert set(result.cams) == {predicted, expected}
+
+
+def test_explain_reuses_map_when_expected_class_is_predicted():
+    model = _TinyCNN(count_forwards=True).eval()
+    input_tensor = torch.randn(1, 3, 8, 8)
+    predicted = model(input_tensor).argmax().item()
+    model.forward_count = 0
+
+    result = explain(model, input_tensor, expected_class_idx=predicted, target_layer="features.1")
+
+    assert model.forward_count == 1
+    assert set(result.cams) == {predicted}
+
+
+def test_explain_supports_torchvision_vit_with_legrad(tmp_path):
+    model = _tiny_vit().eval()
+    result = explain(
+        model,
+        torch.randn(1, 3, 32, 32),
+        method=LeGrad,
+        target_layer=list(model.encoder.layers)[-2:],
+    )
+
+    assert result.method == "LeGrad"
+    assert result.target_layers == ("encoder.layers.encoder_layer_0", "encoder.layers.encoder_layer_1")
+    assert result.cams[result.predicted_class_idx][0].shape == (4, 4)
+    assert torch.isfinite(result.cams[result.predicted_class_idx][0]).all()
+    bundle = result.save(tmp_path / "vit", Image.new("RGB", (32, 32)))
+    artifact = json.loads((bundle / "manifest.json").read_text(encoding="utf-8"))["classes"][
+        str(result.predicted_class_idx)
+    ]["artifacts"][0]
+    assert artifact["target_layers"] == list(result.target_layers)
+
+
+def test_explain_rejects_invalid_inputs_and_outputs(monkeypatch):
+    model = _TinyCNN()
+    input_tensor = torch.randn(1, 3, 8, 8)
+    with pytest.raises(ValueError, match="no CAMs"):
+        explain_module._prepare_maps([])
+    with pytest.raises(ValueError, match="evaluation mode"):
+        explain(model, input_tensor, target_layer="features.1")
+
+    model.eval()
+    with pytest.raises(ValueError, match="shape"):
+        explain(model, torch.randn(2, 3, 8, 8), target_layer="features.1")
+    with pytest.raises(ValueError, match="floating-point"):
+        explain(model, torch.zeros(1, 3, 8, 8, dtype=torch.uint8), target_layer="features.1")
+    with pytest.raises(ValueError, match="output range"):
+        explain(model, input_tensor, expected_class_idx=3, target_layer="features.1")
+    with pytest.raises(ValueError, match="class_names"):
+        explain(model, input_tensor, class_names=["a"], target_layer="features.1")
+    with pytest.raises(TypeError, match="tensor"):
+        explain(_TupleModel().eval(), input_tensor, target_layer="features.1")
+    with pytest.raises(ValueError, match="non-finite logits"):
+        explain(_NonFiniteModel().eval(), input_tensor, target_layer="features.1")
+    prepare_maps = explain_module._prepare_maps
+
+    def inject_non_finite(maps):
+        maps[0][0, 0, 0] = float("nan")
+        return prepare_maps(maps)
+
+    monkeypatch.setattr(explain_module, "_prepare_maps", inject_non_finite)
+    with pytest.raises(ValueError, match="non-finite"):
+        explain(model, input_tensor, target_layer="features.1")
+
+    with torch.inference_mode(), pytest.raises(RuntimeError, match="inference_mode"):
+        explain(model, input_tensor, target_layer="features.1")
+
+
+def test_explain_cleans_hooks_and_preserves_model_state():
+    model = _TinyCNN().eval()
+    input_tensor = torch.randn(1, 3, 8, 8)
+    parameter = next(model.parameters())
+    parameter.grad = torch.ones_like(parameter)
+    gradient = parameter.grad
+    state = {name: value.clone() for name, value in model.state_dict().items()}
+    flags = [parameter.requires_grad for parameter in model.parameters()]
+    modes = [module.training for module in model.modules()]
+    hooks = (len(model.features[1]._forward_hooks), len(model.features[1]._forward_pre_hooks))
+
+    explain(model, input_tensor, target_layer="features.1")
+
+    assert hooks == (len(model.features[1]._forward_hooks), len(model.features[1]._forward_pre_hooks))
+    assert parameter.grad is gradient
+    assert flags == [parameter.requires_grad for parameter in model.parameters()]
+    assert modes == [module.training for module in model.modules()]
+    assert all(torch.equal(value, model.state_dict()[name]) for name, value in state.items())
+    assert input_tensor.grad is None
+
+
+def test_save_writes_complete_deterministic_bundle(tmp_path):
+    model = _TinyCNN().eval()
+    result = explain(
+        model,
+        torch.randn(1, 3, 8, 8),
+        expected_class_idx=0,
+        class_names=["a", "b", "c"],
+        target_layer="features.1",
+    )
+    image = Image.fromarray(np.zeros((13, 19, 3), dtype=np.uint8))
+    bundle = result.save(tmp_path / "bundle", image)
+
+    expected_files = {"manifest.json"}
+    for class_idx in result.cams:
+        expected_files.update({
+            f"class-{class_idx}-layer-0.npy",
+            f"class-{class_idx}-layer-0-heatmap.png",
+            f"class-{class_idx}-layer-0-overlay.png",
+        })
+    assert {path.name for path in bundle.iterdir()} == expected_files
+    for class_idx, maps in result.cams.items():
+        stored = np.load(bundle / f"class-{class_idx}-layer-0.npy", allow_pickle=False)
+        assert stored.dtype == np.float32
+        assert np.array_equal(stored, maps[0].numpy())
+        with Image.open(bundle / f"class-{class_idx}-layer-0-heatmap.png") as heatmap:
+            assert heatmap.mode == "L"
+        with Image.open(bundle / f"class-{class_idx}-layer-0-overlay.png") as overlay:
+            assert overlay.size == image.size
+
+    manifest = json.loads((bundle / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["schema_version"] == 1
+    assert manifest["prediction"]["class_idx"] == result.predicted_class_idx
+    assert manifest["expected"] == {"class_idx": 0, "class_name": "a"}
+    assert manifest["image_size"] == [19, 13]
+    assert manifest["target_layers"] == ["features.1"]
+    for class_data in manifest["classes"].values():
+        assert all("/" not in path for path in class_data["artifacts"][0].values() if isinstance(path, str))
+
+    with pytest.raises(FileExistsError):
+        result.save(bundle, image)
+
+
+def test_save_writes_manifest_only_after_artifacts(tmp_path, monkeypatch):
+    model = _TinyCNN().eval()
+    result = explain(model, torch.randn(1, 3, 8, 8), target_layer="features.1")
+
+    def fail_overlay(*_args, **_kwargs):
+        raise RuntimeError("render failed")
+
+    monkeypatch.setattr(explain_module, "overlay_mask", fail_overlay)
+    with pytest.raises(RuntimeError, match="render failed"):
+        result.save(tmp_path / "incomplete", Image.new("RGB", (8, 8)))
+
+    assert not (tmp_path / "incomplete" / "manifest.json").exists()

--- a/torchcam/__init__.py
+++ b/torchcam/__init__.py
@@ -1,4 +1,4 @@
 from importlib.metadata import version
-from torchcam import methods, metrics, utils
+from torchcam import explain, methods, metrics, utils
 
 __version__ = version("torchcam")

--- a/torchcam/explain.py
+++ b/torchcam/explain.py
@@ -1,0 +1,266 @@
+# Copyright (C) 2020-2026, François-Guillaume Fernandez.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
+
+"""High-level prediction debugging for one image."""
+
+from __future__ import annotations
+
+import json
+import platform
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from importlib.metadata import version
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any
+
+import numpy as np
+import torch
+from PIL.Image import Image, fromarray
+from torch import Tensor, nn
+
+from torchcam.methods import GradCAM
+from torchcam.methods.core import _CAM
+from torchcam.utils import overlay_mask
+
+__all__ = ["PredictionExplanation", "explain"]
+
+
+@dataclass(frozen=True)
+class PredictionExplanation:
+    """Prediction, class activation maps, and reproducibility metadata for one image."""
+
+    logits: Tensor
+    predicted_class_idx: int
+    expected_class_idx: int | None
+    cams: Mapping[int, tuple[Tensor, ...]]
+    method: str
+    target_layers: tuple[str, ...]
+    model: str
+    input_shape: tuple[int, ...]
+    versions: Mapping[str, str]
+    class_names: tuple[str, ...] | None = None
+
+    def save(self, directory: str | Path, image: Image, alpha: float = 0.5) -> Path:
+        """Save NumPy maps, heatmaps, overlays, and a completion manifest to a new directory.
+
+        Args:
+            directory: new output directory
+            image: source image used for full-size overlays
+            alpha: source-image opacity in the overlay
+
+        Returns:
+            output directory
+
+        Raises:
+            TypeError: if the image is not a PIL image
+            FileExistsError: if the output directory already exists
+            ValueError: if the image, alpha, or CAM metadata is unsupported
+        """
+        if not isinstance(image, Image):
+            raise TypeError("`image` must be a PIL image")
+
+        output_dir = Path(directory)
+        if output_dir.exists():
+            raise FileExistsError(f"output directory already exists: {output_dir}")
+        output_dir.mkdir(parents=True)
+        probabilities = self.logits.softmax(dim=1)[0]
+        classes: dict[str, dict[str, Any]] = {}
+
+        for class_idx, maps in sorted(self.cams.items()):
+            artifacts = []
+            if len(maps) == len(self.target_layers):
+                artifact_layers = tuple((name,) for name in self.target_layers)
+            elif len(maps) == 1:
+                artifact_layers = (self.target_layers,)
+            else:
+                raise ValueError("CAM count does not match the resolved target layers")
+
+            for layer_idx, (target_layers, cam) in enumerate(zip(artifact_layers, maps, strict=True)):
+                stem = f"class-{class_idx}-layer-{layer_idx}"
+                array = cam.numpy()
+                npy_path = output_dir / f"{stem}.npy"
+                heatmap_path = output_dir / f"{stem}-heatmap.png"
+                overlay_path = output_dir / f"{stem}-overlay.png"
+
+                np.save(npy_path, array, allow_pickle=False)
+                heatmap = fromarray((255 * np.clip(array, 0, 1)).round().astype(np.uint8))
+                heatmap.save(heatmap_path)
+                overlay_mask(image, heatmap, alpha=alpha).save(overlay_path)
+                artifacts.append({
+                    "target_layers": list(target_layers),
+                    "map": npy_path.name,
+                    "heatmap": heatmap_path.name,
+                    "overlay": overlay_path.name,
+                })
+
+            classes[str(class_idx)] = {
+                "class_idx": class_idx,
+                "class_name": self._class_name(class_idx),
+                "logit": self.logits[0, class_idx].item(),
+                "probability": probabilities[class_idx].item(),
+                "artifacts": artifacts,
+            }
+
+        manifest = {
+            "schema_version": 1,
+            "prediction": self._class_reference(self.predicted_class_idx),
+            "expected": self._class_reference(self.expected_class_idx),
+            "classes": classes,
+            "method": self.method,
+            "target_layers": list(self.target_layers),
+            "model": self.model,
+            "input_shape": list(self.input_shape),
+            "versions": dict(self.versions),
+            "image_size": list(image.size),
+            "alpha": alpha,
+        }
+        (output_dir / "manifest.json").write_text(
+            json.dumps(manifest, indent=2, sort_keys=True, allow_nan=False) + "\n", encoding="utf-8"
+        )
+        return output_dir
+
+    def _class_name(self, class_idx: int) -> str | None:
+        return None if self.class_names is None else self.class_names[class_idx]
+
+    def _class_reference(self, class_idx: int | None) -> dict[str, int | str | None] | None:
+        if class_idx is None:
+            return None
+        return {"class_idx": class_idx, "class_name": self._class_name(class_idx)}
+
+
+def _validate_logits(output: Any) -> Tensor:
+    if not isinstance(output, Tensor):
+        raise TypeError("model output must be a tensor; wrap models that return tuples or dictionaries")
+    if output.ndim != 2 or output.shape[0] != 1 or output.shape[1] < 1:
+        raise ValueError("model output must have shape (1, num_classes)")
+    if not torch.isfinite(output).all():
+        raise ValueError("model output contains non-finite logits")
+    return output
+
+
+def _prepare_maps(maps: list[Tensor]) -> tuple[Tensor, ...]:
+    if not maps:
+        raise ValueError("extractor returned no CAMs")
+    prepared = []
+    for cam in maps:
+        if not isinstance(cam, Tensor) or cam.ndim != 3 or cam.shape[0] != 1:
+            raise ValueError("CAMs must have shape (1, height, width)")
+        if not torch.isfinite(cam).all():
+            raise ValueError("CAM contains non-finite values")
+        prepared.append(cam[0].detach().to(device="cpu", dtype=torch.float32).contiguous())
+    return tuple(prepared)
+
+
+def _validate_request(
+    model: nn.Module,
+    input_tensor: Tensor,
+    expected_class_idx: int | None,
+    method: type[_CAM],
+    method_kwargs: Mapping[str, Any] | None,
+) -> None:
+    if not isinstance(model, nn.Module):
+        raise TypeError("`model` must be a torch.nn.Module")
+    if any(module.training for module in model.modules()):
+        raise ValueError("`model` must be in evaluation mode; call model.eval() first")
+    if not isinstance(input_tensor, Tensor):
+        raise TypeError("`input_tensor` must be a torch.Tensor")
+    if input_tensor.ndim != 4 or input_tensor.shape[0] != 1:
+        raise ValueError("`input_tensor` must have shape (1, channels, height, width)")
+    if not input_tensor.is_floating_point():
+        raise ValueError("`input_tensor` must have a floating-point dtype")
+    if expected_class_idx is not None and (
+        not isinstance(expected_class_idx, int) or isinstance(expected_class_idx, bool)
+    ):
+        raise TypeError("`expected_class_idx` must be an integer or None")
+    if not isinstance(method, type) or not issubclass(method, _CAM):
+        raise TypeError("`method` must be a TorchCAM extractor class")
+    if method_kwargs is not None and not isinstance(method_kwargs, Mapping):
+        raise TypeError("`method_kwargs` must be a mapping or None")
+
+
+def _validate_classes(
+    expected_class_idx: int | None, class_names: Sequence[str] | None, num_classes: int
+) -> tuple[str, ...] | None:
+    if expected_class_idx is not None and not 0 <= expected_class_idx < num_classes:
+        raise ValueError("`expected_class_idx` is outside the model output range")
+    if class_names is None:
+        return None
+    if isinstance(class_names, str) or len(class_names) != num_classes:
+        raise ValueError("`class_names` length must match the number of model classes")
+    if any(not isinstance(name, str) for name in class_names):
+        raise TypeError("every class name must be a string")
+    return tuple(class_names)
+
+
+def explain(
+    model: nn.Module,
+    input_tensor: Tensor,
+    *,
+    expected_class_idx: int | None = None,
+    class_names: Sequence[str] | None = None,
+    method: type[_CAM] = GradCAM,
+    target_layer: nn.Module | str | list[nn.Module | str] | None = None,
+    method_kwargs: Mapping[str, Any] | None = None,
+) -> PredictionExplanation:
+    """Explain the predicted and optional expected class for one 2D image.
+
+    Returns:
+        detached prediction evidence and CAMs
+
+    Raises:
+        RuntimeError: if called from inference mode
+        ValueError: if an argument, model output, or CAM has an unsupported value
+    """
+    if torch.is_inference_mode_enabled():
+        raise RuntimeError("`explain` cannot run inside torch.inference_mode() because CAM extraction needs gradients")
+    _validate_request(model, input_tensor, expected_class_idx, method, method_kwargs)
+
+    kwargs = dict(method_kwargs or {})
+    if "target_layer" in kwargs:
+        raise ValueError("pass `target_layer` directly, not through `method_kwargs`")
+    if target_layer is not None:
+        kwargs["target_layer"] = target_layer
+    elif method is GradCAM:
+        kwargs.setdefault("input_shape", tuple(input_tensor.shape[1:]))
+
+    working_input = input_tensor.detach().requires_grad_(True)
+    parameters = tuple(model.parameters())
+    gradients = tuple(parameter.grad for parameter in parameters)
+
+    try:
+        with torch.enable_grad(), method(model, **kwargs) as extractor:
+            logits = _validate_logits(model(working_input))
+            predicted_class_idx = int(logits[0].argmax().item())
+            validated_class_names = _validate_classes(expected_class_idx, class_names, logits.shape[1])
+
+            cams = {predicted_class_idx: _prepare_maps(extractor(predicted_class_idx, logits))}
+            if expected_class_idx is not None and expected_class_idx != predicted_class_idx:
+                expected_logits = _validate_logits(model(working_input))
+                if expected_logits.shape != logits.shape:
+                    raise ValueError("model output shape changed between explanation forwards")
+                cams[expected_class_idx] = _prepare_maps(extractor(expected_class_idx, expected_logits))
+
+            result = PredictionExplanation(
+                logits=logits.detach().cpu(),
+                predicted_class_idx=predicted_class_idx,
+                expected_class_idx=expected_class_idx,
+                cams=MappingProxyType(cams),
+                method=method.__name__,
+                target_layers=tuple(extractor.target_names),
+                model=f"{model.__class__.__module__}.{model.__class__.__qualname__}",
+                input_shape=tuple(input_tensor.shape),
+                versions=MappingProxyType({
+                    "python": platform.python_version(),
+                    "torch": str(torch.__version__),
+                    "torchcam": version("torchcam"),
+                }),
+                class_names=validated_class_names,
+            )
+    finally:
+        for parameter, gradient in zip(parameters, gradients, strict=True):
+            parameter.grad = gradient
+
+    return result

--- a/torchcam/explain.py
+++ b/torchcam/explain.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 
 import json
 import platform
+import shutil
 from collections.abc import Mapping, Sequence
+from contextlib import ExitStack
 from dataclasses import dataclass
 from importlib.metadata import version
 from pathlib import Path
@@ -66,60 +68,63 @@ class PredictionExplanation:
         if output_dir.exists():
             raise FileExistsError(f"output directory already exists: {output_dir}")
         output_dir.mkdir(parents=True)
-        probabilities = self.logits.softmax(dim=1)[0]
-        classes: dict[str, dict[str, Any]] = {}
+        with ExitStack() as cleanup:
+            cleanup.callback(shutil.rmtree, output_dir)
+            probabilities = self.logits.softmax(dim=1)[0]
+            classes: dict[str, dict[str, Any]] = {}
 
-        for class_idx, maps in sorted(self.cams.items()):
-            artifacts = []
-            if len(maps) == len(self.target_layers):
-                artifact_layers = tuple((name,) for name in self.target_layers)
-            elif len(maps) == 1:
-                artifact_layers = (self.target_layers,)
-            else:
-                raise ValueError("CAM count does not match the resolved target layers")
+            for class_idx, maps in sorted(self.cams.items()):
+                artifacts = []
+                if len(maps) == len(self.target_layers):
+                    artifact_layers = tuple((name,) for name in self.target_layers)
+                elif len(maps) == 1:
+                    artifact_layers = (self.target_layers,)
+                else:
+                    raise ValueError("CAM count does not match the resolved target layers")
 
-            for layer_idx, (target_layers, cam) in enumerate(zip(artifact_layers, maps, strict=True)):
-                stem = f"class-{class_idx}-layer-{layer_idx}"
-                array = cam.numpy()
-                npy_path = output_dir / f"{stem}.npy"
-                heatmap_path = output_dir / f"{stem}-heatmap.png"
-                overlay_path = output_dir / f"{stem}-overlay.png"
+                for layer_idx, (target_layers, cam) in enumerate(zip(artifact_layers, maps, strict=True)):
+                    stem = f"class-{class_idx}-layer-{layer_idx}"
+                    array = cam.numpy()
+                    npy_path = output_dir / f"{stem}.npy"
+                    heatmap_path = output_dir / f"{stem}-heatmap.png"
+                    overlay_path = output_dir / f"{stem}-overlay.png"
 
-                np.save(npy_path, array, allow_pickle=False)
-                heatmap = fromarray((255 * np.clip(array, 0, 1)).round().astype(np.uint8))
-                heatmap.save(heatmap_path)
-                overlay_mask(image, heatmap, alpha=alpha).save(overlay_path)
-                artifacts.append({
-                    "target_layers": list(target_layers),
-                    "map": npy_path.name,
-                    "heatmap": heatmap_path.name,
-                    "overlay": overlay_path.name,
-                })
+                    np.save(npy_path, array, allow_pickle=False)
+                    heatmap = fromarray((255 * np.clip(array, 0, 1)).round().astype(np.uint8))
+                    heatmap.save(heatmap_path)
+                    overlay_mask(image, heatmap, alpha=alpha).save(overlay_path)
+                    artifacts.append({
+                        "target_layers": list(target_layers),
+                        "map": npy_path.name,
+                        "heatmap": heatmap_path.name,
+                        "overlay": overlay_path.name,
+                    })
 
-            classes[str(class_idx)] = {
-                "class_idx": class_idx,
-                "class_name": self._class_name(class_idx),
-                "logit": self.logits[0, class_idx].item(),
-                "probability": probabilities[class_idx].item(),
-                "artifacts": artifacts,
+                classes[str(class_idx)] = {
+                    "class_idx": class_idx,
+                    "class_name": self._class_name(class_idx),
+                    "logit": self.logits[0, class_idx].item(),
+                    "probability": probabilities[class_idx].item(),
+                    "artifacts": artifacts,
+                }
+
+            manifest = {
+                "schema_version": 1,
+                "prediction": self._class_reference(self.predicted_class_idx),
+                "expected": self._class_reference(self.expected_class_idx),
+                "classes": classes,
+                "method": self.method,
+                "target_layers": list(self.target_layers),
+                "model": self.model,
+                "input_shape": list(self.input_shape),
+                "versions": dict(self.versions),
+                "image_size": list(image.size),
+                "alpha": alpha,
             }
-
-        manifest = {
-            "schema_version": 1,
-            "prediction": self._class_reference(self.predicted_class_idx),
-            "expected": self._class_reference(self.expected_class_idx),
-            "classes": classes,
-            "method": self.method,
-            "target_layers": list(self.target_layers),
-            "model": self.model,
-            "input_shape": list(self.input_shape),
-            "versions": dict(self.versions),
-            "image_size": list(image.size),
-            "alpha": alpha,
-        }
-        (output_dir / "manifest.json").write_text(
-            json.dumps(manifest, indent=2, sort_keys=True, allow_nan=False) + "\n", encoding="utf-8"
-        )
+            (output_dir / "manifest.json").write_text(
+                json.dumps(manifest, indent=2, sort_keys=True, allow_nan=False) + "\n", encoding="utf-8"
+            )
+            cleanup.pop_all()
         return output_dir
 
     def _class_name(self, class_idx: int) -> str | None:

--- a/torchcam/explain.py
+++ b/torchcam/explain.py
@@ -59,7 +59,6 @@ class PredictionExplanation:
         Raises:
             TypeError: if the image is not a PIL image
             FileExistsError: if the output directory already exists
-            ValueError: if the image, alpha, or CAM metadata is unsupported
         """
         if not isinstance(image, Image):
             raise TypeError("`image` must be a PIL image")
@@ -75,12 +74,9 @@ class PredictionExplanation:
 
             for class_idx, maps in sorted(self.cams.items()):
                 artifacts = []
-                if len(maps) == len(self.target_layers):
-                    artifact_layers = tuple((name,) for name in self.target_layers)
-                elif len(maps) == 1:
-                    artifact_layers = (self.target_layers,)
-                else:
-                    raise ValueError("CAM count does not match the resolved target layers")
+                artifact_layers = (
+                    (self.target_layers,) if len(maps) == 1 else tuple((name,) for name in self.target_layers)
+                )
 
                 for layer_idx, (target_layers, cam) in enumerate(zip(artifact_layers, maps, strict=True)):
                     stem = f"class-{class_idx}-layer-{layer_idx}"


### PR DESCRIPTION
## Summary

- add a stable `torchcam.explain.explain` result contract for one predicted-versus-expected image-classification case
- save schema-v1 NumPy maps, heatmaps, overlays, and a manifest with an explicit no-overwrite guard
- teach coding agents through a portable skill, focused CNN/ViT documentation, README links, and generated `llms.txt` discovery
- prepare version `0.5.0.dev0` without adding dependencies, loaders, CLI, MCP, or telemetry

## Verification

- `169 passed, 2 skipped` on Python 3.13 with 99% total coverage and 100% coverage for `torchcam/explain.py`
- all pre-commit hooks, Ruff, formatting, typing, dependency sync, strict MkDocs, scripts, wheel/sdist build, and isolated wheel import passed
- three independent skill-assisted acceptance workflows passed: torchvision ResNet18, Holocron ResNet18, and torchvision ViT with LeGrad
- second independent evaluation scored 100% with the skill versus 55.6% unguided
- six adversarial-review harnesses launched; five completed, while DeepSeek timed out without a verdict after 10 minutes
- accepted findings hardened failed-save retryability and validation coverage

## Release boundary

This PR does not publish GitHub Release or PyPI artifacts. The 30-day traffic measurement begins after v0.5.0 is published.