### PR TITLE
feat: support callable output targets

### DIFF
--- a/docs/docs/getting-started/advanced-usage.md
+++ b/docs/docs/getting-started/advanced-usage.md
@@ -14,7 +14,7 @@ what your model accepts and returns:
 | CNN classifier | Native | Class logits shaped `(N, num_classes)` and a spatial target layer. |
 | Batched, 3D, or video classifier | Native | One class index per sample and the correct `input_shape`. |
 | Multi-input model | Adapter required | Wrap the inputs into one tensor argument while preserving the hooked path. |
-| Tensor or per-sample list/tuple output | Native with `targets` | Reduce each sample output to one scalar tensor. |
+| Tensor or per-sample list output | Native with `targets` | Reduce each sample output to one scalar tensor. |
 | torchvision VisionTransformer | Native with `LeGrad` | Target supported encoder blocks; other CAM methods need `reshape_transform`. |
 | Other ViT or Swin classifier | Adapter required | Set `target_layer` and reshape tokens with `reshape_transform`; `LeGrad` only supports the contract below. |
 | Detection, segmentation, embedding, or other output | Native with `targets` | Define a scalar target; gradient methods require it to remain differentiable. |
@@ -134,8 +134,8 @@ cam_extractor(class_idx=None, scores=None, normalized=True, *, targets=None)
   To explain the top prediction use the argmax (`out.squeeze(0).argmax().item()`), but you can pass **any** valid
   index to see where the model looks for that class. For a batch, pass one index per sample (see below).
 - **`scores`** — the raw model output. `class_idx` expects a tensor shaped `(N, num_classes)`; `targets` accepts a
-  batched tensor or one list/tuple item per sample. Required by gradient methods; ignored by `LeGrad`,
-  `SmoothGradCAMpp`, `CAM`, and the Score-CAM family.
+  batched tensor or one list item per sample. Required by gradient methods; ignored by `LeGrad`,
+  `SmoothGradCAMpp`, and `CAM`. The Score-CAM family re-runs the stored input, so `scores` can be omitted.
 - **`targets`** — one callable shared by the batch or one callable per sample. Each callable receives one sample's
   model output and must return a scalar tensor. Pass exactly one of `class_idx` or `targets`.
 - **`normalized`** — when `True` (default) each map is min-max normalized to `[0, 1]`, which is what you want for
@@ -169,8 +169,8 @@ with LayerCAM(model, target_layer="visual.layer4") as cam_extractor:
     cams = cam_extractor(scores=image_embeddings, targets=target)
 ```
 
-Tensor outputs are split along their batch dimension. A model may instead return a list or tuple with one item per
-sample, such as detection dictionaries; in that case each target receives the corresponding item. `GradCAM`,
+Tensor outputs are split along their batch dimension. A model may instead return a list with one item per sample,
+such as detection dictionaries; in that case each target receives the corresponding item. `GradCAM`,
 `GradCAMpp`, `SmoothGradCAMpp`, `XGradCAM`, `LayerCAM`, `ScoreCAM`, `SSCAM`, and `ISCAM` support this contract, as
 does `RefineCAM` when its base method supports it. `CAM`, `FinerCAM`, and `LeGrad` retain their specialized
 class-based objectives.
@@ -192,9 +192,9 @@ with GradCAM(model) as cam_extractor:
 
 ## Models with multiple inputs or batched dictionary outputs
 
-The hooked layer must output a tensor. `targets` handles a batched tensor or a list/tuple containing one output per
-sample. If your model instead returns one dictionary containing batched tensors, or takes several inputs (e.g. a
-siamese network), wrap only that boundary into one of the supported shapes:
+The hooked layer must output a tensor. `targets` handles a batched tensor or a list containing one output per sample.
+Tuple outputs such as `(logits, aux)`, one dictionary containing batched tensors, and models taking several inputs
+(e.g. a siamese network) need a thin wrapper around that boundary:
 
 ```python
 import torch.nn as nn
@@ -373,3 +373,5 @@ for concrete numbers, and the [methods reference](../reference/methods.md) for t
 CAM methods are **post-hoc**: run them on a trained model in `eval()` mode to interpret its predictions — they
 are not a training objective. To quantify how faithful a method is on your own data, use the
 [`ClassificationMetric`](../reference/metrics.md).
+Metrics re-run masked or perturbed inputs in batches, so the model must support batched inference and return the
+same output structure for those forwards.

--- a/docs/docs/getting-started/advanced-usage.md
+++ b/docs/docs/getting-started/advanced-usage.md
@@ -6,23 +6,24 @@ than a usage question? Jump to [Troubleshooting](troubleshooting.md).
 
 ## Model and task compatibility
 
-TorchCAM needs a spatial feature tensor and a scalar class target to explain. The integration path depends on
+TorchCAM needs a spatial feature tensor and a scalar output target to explain. The integration path depends on
 what your model accepts and returns:
 
 | Model or task | Support | What TorchCAM needs |
 | --- | --- | --- |
 | CNN classifier | Native | Class logits shaped `(N, num_classes)` and a spatial target layer. |
 | Batched, 3D, or video classifier | Native | One class index per sample and the correct `input_shape`. |
-| Multi-input model or tuple/dict output | Adapter required | Wrap the model so the hooked path returns one logits tensor. |
+| Multi-input model | Adapter required | Wrap the inputs into one tensor argument while preserving the hooked path. |
+| Tensor or per-sample list/tuple output | Native with `targets` | Reduce each sample output to one scalar tensor. |
 | torchvision VisionTransformer | Native with `LeGrad` | Target supported encoder blocks; other CAM methods need `reshape_transform`. |
 | Other ViT or Swin classifier | Adapter required | Set `target_layer` and reshape tokens with `reshape_transform`; `LeGrad` only supports the contract below. |
-| Detection, segmentation, generative, or non-scalar output | Not supported out of the box | Adapt the model and define the scalar class target to explain. |
+| Detection, segmentation, embedding, or other output | Native with `targets` | Define a scalar target; gradient methods require it to remain differentiable. |
 
 ## Use your own model
 
-TorchCAM works with an `nn.Module` whose forward returns class scores (logits) of shape
-`(N, num_classes)` — it is not limited to torchvision. You only need to tell the extractor which layer to read
-the activations from.
+TorchCAM's class-index API works with an `nn.Module` whose forward returns logits of shape `(N, num_classes)` — it
+is not limited to torchvision. The `targets` API below also supports other batched outputs. In both cases, tell the
+extractor which layer to read the activations from.
 
 List the candidate layers by name:
 
@@ -123,17 +124,20 @@ with FinerCAM(model, "layer4", base_method=LayerCAM) as cam_extractor:
 returns one tensor per selected layer. Its intended behavior is improved discrimination between fine-grained
 classes; it is not a universal guarantee of better localization. Score-based CAM methods are not approximated.
 
-## Understanding `class_idx` and the call signature
+## Understanding targets and the call signature
 
 ```python
-cam_extractor(class_idx, scores=None, normalized=True)
+cam_extractor(class_idx=None, scores=None, normalized=True, *, targets=None)
 ```
 
 - **`class_idx`** (`int` or `list[int]`) — the index, in the output logits, of the class you want to explain.
   To explain the top prediction use the argmax (`out.squeeze(0).argmax().item()`), but you can pass **any** valid
   index to see where the model looks for that class. For a batch, pass one index per sample (see below).
-- **`scores`** — the raw model output of shape `(N, num_classes)`. Required by the gradient-based methods (used
-  for backprop) and by the Score-CAM family; ignored by `LeGrad`, `SmoothGradCAMpp`, and `CAM`.
+- **`scores`** — the raw model output. `class_idx` expects a tensor shaped `(N, num_classes)`; `targets` accepts a
+  batched tensor or one list/tuple item per sample. Required by gradient methods; ignored by `LeGrad`,
+  `SmoothGradCAMpp`, `CAM`, and the Score-CAM family.
+- **`targets`** — one callable shared by the batch or one callable per sample. Each callable receives one sample's
+  model output and must return a scalar tensor. Pass exactly one of `class_idx` or `targets`.
 - **`normalized`** — when `True` (default) each map is min-max normalized to `[0, 1]`, which is what you want for
   visualization/overlay. Pass `normalized=False` to get the raw weighted maps, e.g. when comparing magnitudes
   across layers before fusing them yourself.
@@ -144,6 +148,32 @@ cam_extractor(class_idx, scores=None, normalized=True)
 Gradient-based extractors also accept `retain_graph=True` (forwarded to the gradient computation), needed when you call
 the extractor several times after a single forward — see
 [Troubleshooting](troubleshooting.md#runtimeerror-trying-to-backward-through-the-graph-a-second-time).
+
+`targets` opens the same extractor API to dense predictions and embeddings without a task-specific adapter. For a
+segmentation tensor shaped `(N, classes, H, W)`, explain class 5 inside a region mask:
+
+```python
+with LayerCAM(model, target_layer="backbone.layer4") as cam_extractor:
+    output = model(input_batch)
+    cams = cam_extractor(scores=output, targets=lambda sample: sample[5][region_mask].mean())
+```
+
+For an embedding tensor shaped `(N, embedding_dim)`, the target can be its similarity to another embedding:
+
+```python
+import torch.nn.functional as F
+
+target = lambda embedding: F.cosine_similarity(embedding, text_embedding, dim=0)
+with LayerCAM(model, target_layer="visual.layer4") as cam_extractor:
+    image_embeddings = model(input_batch)
+    cams = cam_extractor(scores=image_embeddings, targets=target)
+```
+
+Tensor outputs are split along their batch dimension. A model may instead return a list or tuple with one item per
+sample, such as detection dictionaries; in that case each target receives the corresponding item. `GradCAM`,
+`GradCAMpp`, `SmoothGradCAMpp`, `XGradCAM`, `LayerCAM`, `ScoreCAM`, `SSCAM`, and `ISCAM` support this contract, as
+does `RefineCAM` when its base method supports it. `CAM`, `FinerCAM`, and `LeGrad` retain their specialized
+class-based objectives.
 
 ## Batched inputs
 
@@ -160,11 +190,11 @@ with GradCAM(model) as cam_extractor:
     cams = cam_extractor(class_ids, out)         # cams[0] has shape (3, H, W)
 ```
 
-## Models with multiple inputs or non-tensor outputs
+## Models with multiple inputs or batched dictionary outputs
 
-The extractor expects the **model output to be the class logits**, and the hooked layer to output a single
-tensor. If your model returns a tuple/dict (e.g. `(logits, aux)`) or takes several inputs (e.g. a siamese
-network), wrap it so the forward used for the CAM returns a single logits tensor:
+The hooked layer must output a tensor. `targets` handles a batched tensor or a list/tuple containing one output per
+sample. If your model instead returns one dictionary containing batched tensors, or takes several inputs (e.g. a
+siamese network), wrap only that boundary into one of the supported shapes:
 
 ```python
 import torch.nn as nn

--- a/tests/test_methods_activation.py
+++ b/tests/test_methods_activation.py
@@ -1,9 +1,21 @@
+from operator import itemgetter
+
 import pytest
 import torch
 from torch import nn
 from torchvision.models import get_model
 
 from torchcam.methods import activation
+
+
+class _StructuredModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.features = nn.Conv2d(1, 2, 1)
+
+    def forward(self, input_tensor):
+        scores = self.features(input_tensor).flatten(2).mean(-1)
+        return [{"primary": row[0], "secondary": row[1]} for row in scores]
 
 
 def test_base_cam_constructor():
@@ -153,6 +165,23 @@ def test_scorecam_restores_state_on_error(cam_name, monkeypatch):
 
         assert extractor._hooks_enabled
         assert model.training
+
+
+@pytest.mark.parametrize("cam_cls", [activation.ScoreCAM, activation.SSCAM, activation.ISCAM])
+def test_score_cams_support_per_sample_output_targets(cam_cls):
+    model = _StructuredModel().eval()
+    kwargs = {"batch_size": 2}
+    if cam_cls is not activation.ScoreCAM:
+        kwargs["num_samples"] = 2
+
+    with cam_cls(model, "features", **kwargs) as extractor:
+        output = model(torch.rand(2, 1, 4, 4))
+        cams = extractor(
+            scores=output,
+            targets=[itemgetter("primary"), itemgetter("secondary")],
+        )
+
+    _verify_cam(cams[0], (2, 4, 4))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_methods_core.py
+++ b/tests/test_methods_core.py
@@ -1,3 +1,5 @@
+from operator import itemgetter
+
 import pytest
 import torch
 
@@ -105,6 +107,32 @@ def test_cam_precheck(mock_img_model, mock_img_tensor):
         if extractor._score_used:
             with pytest.raises(ValueError):
                 extractor(0)
+
+
+def test_output_target_validation(mock_img_model):
+    with core._CAM(mock_img_model, "0.3") as extractor:
+        with pytest.raises(ValueError, match="exactly one"):
+            extractor(0, targets=itemgetter(0))
+        with pytest.raises(ValueError, match="does not support"):
+            extractor(targets=itemgetter(0))
+
+    with pytest.raises(TypeError, match="callable"):
+        core._resolve_targets(0, 1)
+    with pytest.raises(TypeError, match="callable"):
+        core._resolve_targets([0], 1)
+    with pytest.raises(ValueError, match="batch size"):
+        core._resolve_targets([itemgetter(0)], 2)
+
+    with pytest.raises(ValueError, match="batch dimension"):
+        core._target_scores(torch.tensor(1.0), itemgetter(0))
+    with pytest.raises(TypeError, match="tensor or a per-sample list"):
+        core._target_scores((torch.ones(1), torch.ones(1)), itemgetter(0))
+
+    def number_target(_output):
+        return 1
+
+    with pytest.raises(TypeError, match="return a tensor"):
+        core._target_scores(torch.ones(1, 1), number_target)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_methods_gradient.py
+++ b/tests/test_methods_gradient.py
@@ -145,6 +145,29 @@ def test_gradcam_supports_per_sample_output_targets_without_touching_parameter_g
     assert all(torch.equal(parameter.grad, torch.ones_like(parameter)) for parameter in model.parameters())
 
 
+def test_smoothgradcampp_supports_output_targets():
+    model = _StructuredModel().eval()
+
+    with gradient.SmoothGradCAMpp(model, "features", num_samples=2) as extractor:
+        model(torch.rand(2, 1, 4, 4))
+        cams = extractor(targets=itemgetter("primary"))
+
+    _verify_cam(cams[0], (2, 4, 4))
+
+
+def test_gradcam_reports_disconnected_output_target():
+    model = _StructuredModel().eval()
+
+    with gradient.GradCAM(model, "features") as extractor:
+        output = model(torch.rand(1, 1, 4, 4))
+
+        def detached_target(sample):
+            return sample["primary"].detach()
+
+        with pytest.raises(RuntimeError, match="not connected to every target layer"):
+            extractor(scores=output, targets=detached_target)
+
+
 def test_output_target_must_return_a_scalar_tensor():
     model = _tiny_model()
 
@@ -162,6 +185,15 @@ def test_refinecam_supports_output_targets():
         cams = extractor(scores=scores, targets=itemgetter(1))
 
     _verify_cam(cams[0], (2, 4, 4))
+
+
+def test_finercam_rejects_output_targets():
+    model = _tiny_model()
+
+    with gradient.FinerCAM(model, "2") as extractor:
+        scores = model(torch.rand(1, 3, 4, 4))
+        with pytest.raises(ValueError, match="does not support"):
+            extractor(0, scores, targets=itemgetter(0))
 
 
 def test_layercam_fuse_cams():

--- a/tests/test_methods_gradient.py
+++ b/tests/test_methods_gradient.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 from functools import partial
+from operator import itemgetter
 
 import pytest
 import torch
@@ -27,6 +28,16 @@ def _tiny_model(num_classes=3):
         nn.Flatten(1),
         nn.Linear(4, num_classes),
     ).eval()
+
+
+class _StructuredModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.features = nn.Conv2d(1, 2, 1)
+
+    def forward(self, input_tensor):
+        scores = self.features(input_tensor).flatten(2).mean(-1)
+        return [{"primary": row[0], "secondary": row[1]} for row in scores]
 
 
 def _contrastive_scores(scores, class_idx, comparison_idx, gamma):
@@ -115,6 +126,42 @@ def test_smoothgradcampp_repr():
     # Hook the corresponding layer in the model
     with gradient.SmoothGradCAMpp(model, "features.18.0") as extractor:
         assert repr(extractor) == "SmoothGradCAMpp(target_layer=['features.18.0'], num_samples=4, std=0.3)"
+
+
+def test_gradcam_supports_per_sample_output_targets_without_touching_parameter_grads():
+    model = _StructuredModel().eval()
+    input_tensor = torch.rand(2, 1, 4, 4)
+
+    with gradient.GradCAM(model, "features") as extractor:
+        output = model(input_tensor)
+        for parameter in model.parameters():
+            parameter.grad = torch.ones_like(parameter)
+        cams = extractor(
+            scores=output,
+            targets=[itemgetter("primary"), itemgetter("secondary")],
+        )
+
+    _verify_cam(cams[0], (2, 4, 4))
+    assert all(torch.equal(parameter.grad, torch.ones_like(parameter)) for parameter in model.parameters())
+
+
+def test_output_target_must_return_a_scalar_tensor():
+    model = _tiny_model()
+
+    with gradient.GradCAM(model, "2") as extractor:
+        scores = model(torch.rand(1, 3, 4, 4))
+        with pytest.raises(ValueError, match="scalar tensor"):
+            extractor(scores=scores, targets=itemgetter(slice(2)))
+
+
+def test_refinecam_supports_output_targets():
+    model = _tiny_model()
+
+    with gradient.RefineCAM(model, ["0", "2"], base_method=gradient.LayerCAM) as extractor:
+        scores = model(torch.rand(2, 3, 4, 4))
+        cams = extractor(scores=scores, targets=itemgetter(1))
+
+    _verify_cam(cams[0], (2, 4, 4))
 
 
 def test_layercam_fuse_cams():
@@ -497,7 +544,7 @@ def test_gradcam_does_not_accumulate_hook_handles(mock_img_tensor):
             scores = model(mock_img_tensor)
             extractor(scores[0].argmax().item(), scores, retain_graph=True)
         assert len(extractor.hook_handles) == initial_handles
-        assert len(extractor._grad_hook_handles) == len(extractor.target_names)
+        assert len(extractor._hook_outputs) == len(extractor.target_names)
 
 
 def test_smoothgradcampp_restores_input_hook_on_error(mock_img_tensor, monkeypatch):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
 from functools import partial
+from operator import itemgetter
 
 import pytest
 import torch
@@ -48,7 +49,7 @@ class _FixedExtractor:
         self._hooks_enabled = True
         self.class_idx = None
 
-    def __call__(self, class_idx, scores=None, _normalized=True, **_kwargs):
+    def __call__(self, class_idx=None, scores=None, _normalized=True, **_kwargs):
         self.class_idx = class_idx
         cam = self.cam.to(scores)
         if cam.shape[0] == 1 and scores.shape[0] > 1:
@@ -115,6 +116,16 @@ def test_classification_metric_exact_value():
     assert metric.summary() == pytest.approx({"avg_drop": 0.6 / (1 + 1e-7), "conf_increase": 0})
 
 
+def test_classification_metric_accepts_output_targets():
+    model = _SumClassifier()
+    extractor = _FixedExtractor(model, torch.tensor([[[1.0, 0.0], [0.0, 0.0]]]))
+    metric = metrics.ClassificationMetric(extractor)
+
+    metric.update(_exact_input(), targets=itemgetter(0))
+
+    assert metric.summary() == pytest.approx({"avg_drop": 0.6 / (1 + 1e-7), "conf_increase": 0})
+
+
 def test_deletion_insertion_complete_curves_and_auc():
     metric = _fixed_metric(steps=2)
     input_tensor = _exact_input()
@@ -134,6 +145,14 @@ def test_deletion_insertion_complete_curves_and_auc():
     assert torch.trapezoid(insertion, fractions).item() == pytest.approx(0.6)
 
     metric.update(input_tensor, class_idx=0)
+    assert metric.summary() == pytest.approx({"deletion_auc": 0.4, "insertion_auc": 0.6})
+
+
+def test_deletion_insertion_accepts_output_targets():
+    metric = _fixed_metric(steps=2)
+
+    metric.update(_exact_input(), targets=itemgetter(0))
+
     assert metric.summary() == pytest.approx({"deletion_auc": 0.4, "insertion_auc": 0.6})
 
 

--- a/torchcam/methods/__init__.py
+++ b/torchcam/methods/__init__.py
@@ -1,2 +1,3 @@
 from .activation import *
+from .core import OutputTarget
 from .gradient import *

--- a/torchcam/methods/activation.py
+++ b/torchcam/methods/activation.py
@@ -190,25 +190,21 @@ class ScoreCAM(_CAM):
         chunk = buffer[: slice_.stop - slice_.start]
         return torch.mul(masks[slice_], model_input, out=chunk)
 
-    def _score_delta(
-        self,
-        input_tensor: Tensor,
-        baseline_output: Any,
+    @staticmethod
+    def _select_scores(
+        output: Any,
         sample_indices: Tensor,
         class_idx: int | list[int] | None,
         targets: list[OutputTarget] | None,
-        baseline_scores: Tensor | None,
     ) -> Tensor:
-        output = self.model(input_tensor)
         if targets is not None:
             selected_targets = [targets[idx] for idx in sample_indices.tolist()]
-            return _target_scores(output, selected_targets) - cast(Tensor, baseline_scores)[sample_indices]
+            return _target_scores(output, selected_targets)
 
-        score_delta = cast(Tensor, output) - cast(Tensor, baseline_output)[sample_indices]
         if isinstance(class_idx, int):
-            return score_delta[:, class_idx]
-        indices = torch.tensor(class_idx, device=score_delta.device)[sample_indices]
-        return score_delta.gather(1, indices.view(-1, 1)).squeeze(1)
+            return cast(Tensor, output)[:, class_idx]
+        indices = torch.tensor(class_idx, device=cast(Tensor, output).device)[sample_indices]
+        return cast(Tensor, output).gather(1, indices.view(-1, 1)).squeeze(1)
 
     @torch.no_grad()
     def _get_score_weights(
@@ -228,7 +224,8 @@ class ScoreCAM(_CAM):
         # (N, M)
         logits = self.model(self._input)
         target_fns = _resolve_targets(targets, activations[0].shape[0]) if targets is not None else None
-        baseline_scores = _target_scores(logits, target_fns) if target_fns is not None else None
+        batch_indices = torch.arange(activations[0].shape[0])
+        baseline_scores = self._select_scores(logits, batch_indices, class_idx, target_fns)
 
         for (masks, sample_indices, buffer), weight in zip(prepared_inputs, weights, strict=True):
             # Process by chunk (GPU RAM limitation)
@@ -236,14 +233,14 @@ class ScoreCAM(_CAM):
                 slice_ = slice(idx_ * self.bs, min((idx_ + 1) * self.bs, weight.numel()))
                 # Get the softmax probabilities of the target class
                 # (*, M)
-                weight[slice_] = self._score_delta(
-                    self._masked_input_chunk(masks, sample_indices, buffer, slice_),
-                    logits,
-                    sample_indices[slice_],
+                chunk_indices = sample_indices[slice_]
+                chunk_scores = self._select_scores(
+                    self.model(self._masked_input_chunk(masks, sample_indices, buffer, slice_)),
+                    chunk_indices,
                     class_idx,
                     target_fns,
-                    baseline_scores,
                 )
+                weight[slice_] = chunk_scores - baseline_scores[chunk_indices]
 
         # Reshape the weights (N, C)
         return [
@@ -368,7 +365,8 @@ class SSCAM(ScoreCAM):
         # (N, M)
         logits = self.model(self._input)
         target_fns = _resolve_targets(targets, activations[0].shape[0]) if targets is not None else None
-        baseline_scores = _target_scores(logits, target_fns) if target_fns is not None else None
+        batch_indices = torch.arange(activations[0].shape[0])
+        baseline_scores = self._select_scores(logits, batch_indices, class_idx, target_fns)
 
         for activation, weight in zip(activations, weights, strict=True):
             # Add noise
@@ -380,14 +378,14 @@ class SSCAM(ScoreCAM):
                 for idx_ in range(math.ceil(weight.numel() / self.bs)):
                     slice_ = slice(idx_ * self.bs, min((idx_ + 1) * self.bs, weight.numel()))
                     # Get the softmax probabilities of the target class
-                    weight[slice_] += self._score_delta(
-                        self._masked_input_chunk(masks, sample_indices, buffer, slice_),
-                        logits,
-                        sample_indices[slice_],
+                    chunk_indices = sample_indices[slice_]
+                    chunk_scores = self._select_scores(
+                        self.model(self._masked_input_chunk(masks, sample_indices, buffer, slice_)),
+                        chunk_indices,
                         class_idx,
                         target_fns,
-                        baseline_scores,
                     )
+                    weight[slice_] += chunk_scores - baseline_scores[chunk_indices]
 
         # Reshape the weights (N, C)
         return [
@@ -477,7 +475,8 @@ class ISCAM(ScoreCAM):
         # (N, M)
         logits = self.model(self._input)
         target_fns = _resolve_targets(targets, activations[0].shape[0]) if targets is not None else None
-        baseline_scores = _target_scores(logits, target_fns) if target_fns is not None else None
+        batch_indices = torch.arange(activations[0].shape[0])
+        baseline_scores = self._select_scores(logits, batch_indices, class_idx, target_fns)
 
         for (masks, sample_indices, buffer), weight in zip(prepared_inputs, weights, strict=True):
             coeff = 0.0
@@ -489,14 +488,14 @@ class ISCAM(ScoreCAM):
                 for idx_ in range(math.ceil(weight.numel() / self.bs)):
                     slice_ = slice(idx_ * self.bs, min((idx_ + 1) * self.bs, weight.numel()))
                     # Get the softmax probabilities of the target class
-                    weight[slice_] += self._score_delta(
-                        coeff * self._masked_input_chunk(masks, sample_indices, buffer, slice_),
-                        logits,
-                        sample_indices[slice_],
+                    chunk_indices = sample_indices[slice_]
+                    chunk_scores = self._select_scores(
+                        self.model(coeff * self._masked_input_chunk(masks, sample_indices, buffer, slice_)),
+                        chunk_indices,
                         class_idx,
                         target_fns,
-                        baseline_scores,
                     )
+                    weight[slice_] += chunk_scores - baseline_scores[chunk_indices]
 
         # Reshape the weights (N, C)
         return [

--- a/torchcam/methods/activation.py
+++ b/torchcam/methods/activation.py
@@ -5,13 +5,13 @@
 
 import logging
 import math
-from typing import Any
+from typing import Any, cast
 
 import torch
 import torch.nn.functional as F
 from torch import Tensor, nn
 
-from .core import _CAM
+from .core import _CAM, OutputTarget, _resolve_targets, _target_scores
 
 __all__ = ["CAM", "ISCAM", "SSCAM", "ScoreCAM"]
 
@@ -164,6 +164,7 @@ class ScoreCAM(_CAM):
         self.bs = batch_size
         # Ensure ReLU is applied to CAM before normalization
         self._relu = True
+        self._targets_supported = True
 
     def _store_input(self, _: nn.Module, input_: tuple[Any, ...]) -> None:
         """Store model input tensor."""
@@ -189,8 +190,33 @@ class ScoreCAM(_CAM):
         chunk = buffer[: slice_.stop - slice_.start]
         return torch.mul(masks[slice_], model_input, out=chunk)
 
+    def _score_delta(
+        self,
+        input_tensor: Tensor,
+        baseline_output: Any,
+        sample_indices: Tensor,
+        class_idx: int | list[int] | None,
+        targets: list[OutputTarget] | None,
+        baseline_scores: Tensor | None,
+    ) -> Tensor:
+        output = self.model(input_tensor)
+        if targets is not None:
+            selected_targets = [targets[idx] for idx in sample_indices.tolist()]
+            return _target_scores(output, selected_targets) - cast(Tensor, baseline_scores)[sample_indices]
+
+        score_delta = cast(Tensor, output) - cast(Tensor, baseline_output)[sample_indices]
+        if isinstance(class_idx, int):
+            return score_delta[:, class_idx]
+        indices = torch.tensor(class_idx, device=score_delta.device)[sample_indices]
+        return score_delta.gather(1, indices.view(-1, 1)).squeeze(1)
+
     @torch.no_grad()
-    def _get_score_weights(self, activations: list[Tensor], class_idx: int | list[int]) -> list[Tensor]:
+    def _get_score_weights(
+        self,
+        activations: list[Tensor],
+        class_idx: int | list[int] | None,
+        targets: OutputTarget | list[OutputTarget] | None = None,
+    ) -> list[Tensor]:
         prepared_inputs = [self._prepare_masked_inputs(act) for act in activations]
 
         # Initialize weights
@@ -201,6 +227,8 @@ class ScoreCAM(_CAM):
 
         # (N, M)
         logits = self.model(self._input)
+        target_fns = _resolve_targets(targets, activations[0].shape[0]) if targets is not None else None
+        baseline_scores = _target_scores(logits, target_fns) if target_fns is not None else None
 
         for (masks, sample_indices, buffer), weight in zip(prepared_inputs, weights, strict=True):
             # Process by chunk (GPU RAM limitation)
@@ -208,13 +236,14 @@ class ScoreCAM(_CAM):
                 slice_ = slice(idx_ * self.bs, min((idx_ + 1) * self.bs, weight.numel()))
                 # Get the softmax probabilities of the target class
                 # (*, M)
-                baseline = logits if logits.shape[0] == 1 else logits[sample_indices[slice_]]
-                cic = self.model(self._masked_input_chunk(masks, sample_indices, buffer, slice_)) - baseline
-                if isinstance(class_idx, int):
-                    weight[slice_] = cic[:, class_idx]
-                else:
-                    chunk_target = torch.tensor(class_idx, device=cic.device)[sample_indices[slice_]]
-                    weight[slice_] = cic.gather(1, chunk_target.view(-1, 1)).squeeze(1)
+                weight[slice_] = self._score_delta(
+                    self._masked_input_chunk(masks, sample_indices, buffer, slice_),
+                    logits,
+                    sample_indices[slice_],
+                    class_idx,
+                    target_fns,
+                    baseline_scores,
+                )
 
         # Reshape the weights (N, C)
         return [
@@ -225,8 +254,9 @@ class ScoreCAM(_CAM):
     @torch.no_grad()
     def _get_weights(
         self,
-        class_idx: int | list[int],
+        class_idx: int | list[int] | None,
         *_: Any,
+        targets: OutputTarget | list[OutputTarget] | None = None,
     ) -> list[Tensor]:
         """Computes the weight coefficients of the hooked activation maps."""  # noqa: DOC201
         self.hook_a: list[Tensor]  # type: ignore[assignment]
@@ -250,7 +280,7 @@ class ScoreCAM(_CAM):
         ]
 
         with self._hooks_off(), self._eval_mode():
-            return self._get_score_weights(upsampled_a, class_idx)
+            return self._get_score_weights(upsampled_a, class_idx, targets)
 
     def __repr__(self) -> str:  # noqa: D105
         return f"{self.__class__.__name__}(batch_size={self.bs})"
@@ -323,7 +353,12 @@ class SSCAM(ScoreCAM):
         self._distrib = torch.distributions.normal.Normal(0, self.std)
 
     @torch.no_grad()
-    def _get_score_weights(self, activations: list[Tensor], class_idx: int | list[int]) -> list[Tensor]:
+    def _get_score_weights(
+        self,
+        activations: list[Tensor],
+        class_idx: int | list[int] | None,
+        targets: OutputTarget | list[OutputTarget] | None = None,
+    ) -> list[Tensor]:
         # Initialize weights
         # (N * C)
         weights = [
@@ -332,6 +367,8 @@ class SSCAM(ScoreCAM):
 
         # (N, M)
         logits = self.model(self._input)
+        target_fns = _resolve_targets(targets, activations[0].shape[0]) if targets is not None else None
+        baseline_scores = _target_scores(logits, target_fns) if target_fns is not None else None
 
         for activation, weight in zip(activations, weights, strict=True):
             # Add noise
@@ -343,13 +380,14 @@ class SSCAM(ScoreCAM):
                 for idx_ in range(math.ceil(weight.numel() / self.bs)):
                     slice_ = slice(idx_ * self.bs, min((idx_ + 1) * self.bs, weight.numel()))
                     # Get the softmax probabilities of the target class
-                    baseline = logits if logits.shape[0] == 1 else logits[sample_indices[slice_]]
-                    cic = self.model(self._masked_input_chunk(masks, sample_indices, buffer, slice_)) - baseline
-                    if isinstance(class_idx, int):
-                        weight[slice_] += cic[:, class_idx]
-                    else:
-                        chunk_target = torch.tensor(class_idx, device=cic.device)[sample_indices[slice_]]
-                        weight[slice_] += cic.gather(1, chunk_target.view(-1, 1)).squeeze(1)
+                    weight[slice_] += self._score_delta(
+                        self._masked_input_chunk(masks, sample_indices, buffer, slice_),
+                        logits,
+                        sample_indices[slice_],
+                        class_idx,
+                        target_fns,
+                        baseline_scores,
+                    )
 
         # Reshape the weights (N, C)
         return [
@@ -423,7 +461,12 @@ class ISCAM(ScoreCAM):
         self.num_samples = num_samples
 
     @torch.no_grad()
-    def _get_score_weights(self, activations: list[Tensor], class_idx: int | list[int]) -> list[Tensor]:
+    def _get_score_weights(
+        self,
+        activations: list[Tensor],
+        class_idx: int | list[int] | None,
+        targets: OutputTarget | list[OutputTarget] | None = None,
+    ) -> list[Tensor]:
         prepared_inputs = [self._prepare_masked_inputs(act) for act in activations]
 
         # Initialize weights
@@ -433,6 +476,8 @@ class ISCAM(ScoreCAM):
 
         # (N, M)
         logits = self.model(self._input)
+        target_fns = _resolve_targets(targets, activations[0].shape[0]) if targets is not None else None
+        baseline_scores = _target_scores(logits, target_fns) if target_fns is not None else None
 
         for (masks, sample_indices, buffer), weight in zip(prepared_inputs, weights, strict=True):
             coeff = 0.0
@@ -444,13 +489,14 @@ class ISCAM(ScoreCAM):
                 for idx_ in range(math.ceil(weight.numel() / self.bs)):
                     slice_ = slice(idx_ * self.bs, min((idx_ + 1) * self.bs, weight.numel()))
                     # Get the softmax probabilities of the target class
-                    baseline = logits if logits.shape[0] == 1 else logits[sample_indices[slice_]]
-                    cic = self.model(coeff * self._masked_input_chunk(masks, sample_indices, buffer, slice_)) - baseline
-                    if isinstance(class_idx, int):
-                        weight[slice_] += cic[:, class_idx]
-                    else:
-                        chunk_target = torch.tensor(class_idx, device=cic.device)[sample_indices[slice_]]
-                        weight[slice_] += cic.gather(1, chunk_target.view(-1, 1)).squeeze(1)
+                    weight[slice_] += self._score_delta(
+                        coeff * self._masked_input_chunk(masks, sample_indices, buffer, slice_),
+                        logits,
+                        sample_indices[slice_],
+                        class_idx,
+                        target_fns,
+                        baseline_scores,
+                    )
 
         # Reshape the weights (N, C)
         return [

--- a/torchcam/methods/core.py
+++ b/torchcam/methods/core.py
@@ -17,9 +17,39 @@ from torch import Tensor, nn
 
 from ._utils import locate_candidate_layer
 
-__all__ = ["_CAM"]
+__all__ = ["_CAM", "OutputTarget"]
 
 logger = logging.getLogger(__name__)
+
+OutputTarget = Callable[[Any], Tensor]
+
+
+def _resolve_targets(targets: OutputTarget | list[OutputTarget], batch_size: int) -> list[OutputTarget]:
+    if callable(targets):
+        return [cast(OutputTarget, targets)] * batch_size
+    if not isinstance(targets, list) or any(not callable(target) for target in targets):
+        raise TypeError("targets must be a callable or a list of callables")
+    if len(targets) != batch_size:
+        raise ValueError("per-sample targets must match the batch size")
+    return targets
+
+
+def _target_scores(output: Any, targets: OutputTarget | list[OutputTarget]) -> Tensor:
+    if isinstance(output, Tensor):
+        if output.ndim == 0:
+            raise ValueError("model output must have a batch dimension")
+        samples: tuple[Any, ...] | list[Any] = output.unbind(0)
+    elif isinstance(output, (list, tuple)):
+        samples = output
+    else:
+        raise TypeError("model output must be a tensor, list, or tuple")
+
+    values = [target(sample) for target, sample in zip(_resolve_targets(targets, len(samples)), samples, strict=True)]
+    if any(not isinstance(value, Tensor) for value in values):
+        raise TypeError("each target must return a tensor")
+    if any(value.numel() != 1 for value in values):
+        raise ValueError("each target must return a scalar tensor")
+    return torch.stack([value.reshape(()) for value in values])
 
 
 class _CAM:
@@ -93,6 +123,8 @@ class _CAM:
         self._relu = False
         # Model output is used by the extractor
         self._score_used = False
+        # Arbitrary scalar output targets are supported by the extractor
+        self._targets_supported = False
 
     def enable_hooks(self) -> None:
         """Enable hooks."""
@@ -175,44 +207,64 @@ class _CAM:
     def _get_weights(self, class_idx: int | list[int], *args: Any, **kwargs: Any) -> list[Tensor]:
         raise NotImplementedError
 
-    def _precheck(self, class_idx: int | list[int], scores: Tensor | None = None) -> None:
+    def _precheck(
+        self,
+        class_idx: int | list[int] | None,
+        scores: Any = None,
+        targets: OutputTarget | list[OutputTarget] | None = None,
+    ) -> None:
         """Check for invalid computation cases."""  # noqa: DOC501
+        if (class_idx is None) == (targets is None):
+            raise ValueError("provide exactly one of class_idx or targets")
+        if targets is not None and not self._targets_supported:
+            raise ValueError(f"{self.__class__.__name__} does not support arbitrary output targets")
+
         for fmap in self.hook_a:
             # Check that forward has already occurred
             if not isinstance(fmap, Tensor):
                 raise AssertionError("Inputs need to be forwarded in the model for the conv features to be hooked")  # noqa: TRY004
             # Check batch size
-            if not isinstance(class_idx, int) and fmap.shape[0] != len(class_idx):
+            if isinstance(class_idx, list) and fmap.shape[0] != len(class_idx):
                 raise ValueError("expected batch size and length of `class_idx` to be the same.")
+            if targets is not None:
+                _resolve_targets(targets, fmap.shape[0])
 
         # Check class_idx value
-        if (not isinstance(class_idx, int) or class_idx < 0) and (
-            not isinstance(class_idx, list) or any(idx < 0 for idx in class_idx)
+        if (
+            targets is None
+            and (not isinstance(class_idx, int) or class_idx < 0)
+            and (not isinstance(class_idx, list) or any(idx < 0 for idx in class_idx))
         ):
             raise ValueError("Incorrect `class_idx` argument value")
 
         # Check scores arg
-        if self._score_used and not isinstance(scores, torch.Tensor):
+        if self._score_used and scores is None:
             raise ValueError("model output scores is required to be passed to compute CAMs")
+        if self._score_used and targets is None and not isinstance(scores, Tensor):
+            raise TypeError("model output scores must be a tensor when using class_idx")
 
     def __call__(
         self,
-        class_idx: int | list[int],
-        scores: Tensor | None = None,
+        class_idx: int | list[int] | None = None,
+        scores: Any = None,
         normalized: bool = True,
+        *,
+        targets: OutputTarget | list[OutputTarget] | None = None,
         **kwargs: Any,
     ) -> list[Tensor]:
         # Integrity check
-        self._precheck(class_idx, scores)
+        self._precheck(class_idx, scores, targets)
 
         # Compute CAM
-        return self.compute_cams(class_idx, scores, normalized, **kwargs)
+        return self.compute_cams(class_idx, scores, normalized, targets=targets, **kwargs)
 
     def compute_cams(
         self,
-        class_idx: int | list[int],
-        scores: Tensor | None = None,
+        class_idx: int | list[int] | None = None,
+        scores: Any = None,
         normalized: bool = True,
+        *,
+        targets: OutputTarget | list[OutputTarget] | None = None,
         **kwargs: Any,
     ) -> list[Tensor]:
         """Compute the CAM for a specific output class.
@@ -222,6 +274,7 @@ class _CAM:
                 the list needs to have valid class indices and have a length equal to the batch size.
             scores: forward output scores of the hooked model of shape (N, K)
             normalized: whether the CAM should be normalized
+            targets: scalar output target shared by the batch, or one target per sample
             kwargs: keyword args of `_get_weights` method
 
         Returns:
@@ -230,7 +283,9 @@ class _CAM:
                 the k-th element of the input batch for class index equal to the k-th element of `class_idx`.
         """
         # Get map weight & unsqueeze it
-        weights = self._get_weights(class_idx, scores, **kwargs)
+        if targets is not None:
+            kwargs["targets"] = targets
+        weights = self._get_weights(cast(int | list[int], class_idx), scores, **kwargs)
 
         cams: list[Tensor] = []
         activations = cast(list[Tensor], self.hook_a)

--- a/torchcam/methods/core.py
+++ b/torchcam/methods/core.py
@@ -39,10 +39,10 @@ def _target_scores(output: Any, targets: OutputTarget | list[OutputTarget]) -> T
         if output.ndim == 0:
             raise ValueError("model output must have a batch dimension")
         samples: tuple[Any, ...] | list[Any] = output.unbind(0)
-    elif isinstance(output, (list, tuple)):
+    elif isinstance(output, list):
         samples = output
     else:
-        raise TypeError("model output must be a tensor, list, or tuple")
+        raise TypeError("model output must be a tensor or a per-sample list")
 
     values = [target(sample) for target, sample in zip(_resolve_targets(targets, len(samples)), samples, strict=True)]
     if any(not isinstance(value, Tensor) for value in values):
@@ -226,8 +226,8 @@ class _CAM:
             # Check batch size
             if isinstance(class_idx, list) and fmap.shape[0] != len(class_idx):
                 raise ValueError("expected batch size and length of `class_idx` to be the same.")
-            if targets is not None:
-                _resolve_targets(targets, fmap.shape[0])
+        if targets is not None:
+            _resolve_targets(targets, cast(Tensor, self.hook_a[0]).shape[0])
 
         # Check class_idx value
         if (

--- a/torchcam/methods/gradient.py
+++ b/torchcam/methods/gradient.py
@@ -61,7 +61,11 @@ class _GradCAM(_CAM):
         retain_graph: bool = False,
         targets: OutputTarget | list[OutputTarget] | None = None,
     ) -> None:
-        """Backpropagate the loss for a specific output class."""
+        """Backpropagate the loss for a specific output class.
+
+        Raises:
+            RuntimeError: if the target score is disconnected from a target layer
+        """
         if targets is not None:
             loss = _target_scores(scores, targets).sum()
         elif isinstance(class_idx, int):
@@ -69,7 +73,10 @@ class _GradCAM(_CAM):
         else:
             loss = scores.gather(1, torch.tensor(class_idx, device=scores.device).view(-1, 1)).sum()
         outputs = cast(list[Tensor], self._hook_outputs)
-        gradients = torch.autograd.grad(loss, outputs, retain_graph=retain_graph)
+        try:
+            gradients = torch.autograd.grad(loss, outputs, retain_graph=retain_graph)
+        except RuntimeError as exc:
+            raise RuntimeError("target score is not connected to every target layer") from exc
         for idx, gradient in enumerate(gradients):
             transformed = self._reshape_transform(gradient) if self._reshape_transform is not None else gradient
             self.hook_g[idx] = transformed.detach()
@@ -1080,7 +1087,13 @@ class FinerCAM(_CAMWrapper):
         normalized: bool = True,
         **kwargs: Any,
     ) -> list[Tensor]:
-        """Compute Finer-CAMs for the target and comparison classes."""  # noqa: DOC201
+        """Compute Finer-CAMs for the target and comparison classes.
+
+        Raises:
+            ValueError: if arbitrary output targets are provided
+        """  # noqa: DOC201
+        if kwargs.get("targets") is not None:
+            raise ValueError("FinerCAM does not support arbitrary output targets")
         contrastive_scores = self._contrastive_scores(class_idx, scores, comparison_idx)
         # The contrastive objective is the sole score column, at class index 0.
         return self.base_cam([0] * contrastive_scores.shape[0], contrastive_scores, normalized, **kwargs)
@@ -1093,7 +1106,13 @@ class FinerCAM(_CAMWrapper):
         normalized: bool = True,
         **kwargs: Any,
     ) -> list[Tensor]:
-        """Compute Finer-CAMs without the base extractor precheck."""  # noqa: DOC201
+        """Compute Finer-CAMs without the base extractor precheck.
+
+        Raises:
+            ValueError: if arbitrary output targets are provided
+        """  # noqa: DOC201
+        if kwargs.get("targets") is not None:
+            raise ValueError("FinerCAM does not support arbitrary output targets")
         contrastive_scores = self._contrastive_scores(class_idx, scores, comparison_idx)
         return self.base_cam.compute_cams([0] * contrastive_scores.shape[0], contrastive_scores, normalized, **kwargs)
 

--- a/torchcam/methods/gradient.py
+++ b/torchcam/methods/gradient.py
@@ -14,7 +14,7 @@ import torch
 from torch import Tensor, nn
 from torch.nn import functional as F
 
-from .core import _CAM
+from .core import _CAM, OutputTarget, _target_scores
 
 __all__ = ["FinerCAM", "GradCAM", "GradCAMpp", "LayerCAM", "LeGrad", "RefineCAM", "SmoothGradCAMpp", "XGradCAM"]
 
@@ -40,46 +40,39 @@ class _GradCAM(_CAM):
         self._relu = True
         # Model output is used by the extractor
         self._score_used = True
+        self._targets_supported = True
         for idx, name in enumerate(self.target_names):
             # Trick to avoid issues with inplace operations cf. https://github.com/pytorch/pytorch/issues/61519
             self.hook_handles.append(self.submodule_dict[name].register_forward_hook(partial(self._hook_g, idx=idx)))
-        self._grad_hook_handles: list[torch.utils.hooks.RemovableHandle | None] = [None] * len(self.target_names)
 
-    def _store_grad(self, grad: Tensor, idx: int = 0) -> None:
-        if self._hooks_enabled:
-            if self._reshape_transform is not None:
-                grad = self._reshape_transform(grad)
-            self.hook_g[idx] = grad.detach()
+    def reset_hooks(self) -> None:
+        super().reset_hooks()
+        self._hook_outputs: list[Tensor | None] = [None] * len(self.target_names)
 
     def _hook_g(self, _: nn.Module, _input: tuple[Tensor, ...], output: Tensor, idx: int = 0) -> None:
-        """Gradient hook."""
+        """Store the target-layer output used to compute gradients."""
         if self._hooks_enabled:
-            handle = self._grad_hook_handles[idx]
-            if handle is not None:
-                handle.remove()
-            self._grad_hook_handles[idx] = output.register_hook(partial(self._store_grad, idx=idx))
-
-    def remove_hooks(self) -> None:
-        for handle in self._grad_hook_handles:
-            if handle is not None:
-                handle.remove()
-        self._grad_hook_handles = [None] * len(self.target_names)
-        super().remove_hooks()
+            self._hook_outputs[idx] = output
 
     def _backprop(
         self,
-        scores: Tensor,
-        class_idx: int | list[int],
+        scores: Any,
+        class_idx: int | list[int] | None,
         retain_graph: bool = False,
+        targets: OutputTarget | list[OutputTarget] | None = None,
     ) -> None:
         """Backpropagate the loss for a specific output class."""
-        # Backpropagate to get the gradients on the hooked layer
-        if isinstance(class_idx, int):
+        if targets is not None:
+            loss = _target_scores(scores, targets).sum()
+        elif isinstance(class_idx, int):
             loss = scores[:, class_idx].sum()
         else:
             loss = scores.gather(1, torch.tensor(class_idx, device=scores.device).view(-1, 1)).sum()
-        self.model.zero_grad()
-        loss.backward(retain_graph=retain_graph)
+        outputs = cast(list[Tensor], self._hook_outputs)
+        gradients = torch.autograd.grad(loss, outputs, retain_graph=retain_graph)
+        for idx, gradient in enumerate(gradients):
+            transformed = self._reshape_transform(gradient) if self._reshape_transform is not None else gradient
+            self.hook_g[idx] = transformed.detach()
 
 
 class GradCAM(_GradCAM):
@@ -326,7 +319,6 @@ class SmoothGradCAMpp(_GradCAM):
             noisy_input.requires_grad_(True)
             # Forward & Backward
             out = self.model(noisy_input)
-            self.model.zero_grad()
             self._backprop(out, class_idx, **kwargs)
 
             # Sum partial derivatives
@@ -745,8 +737,13 @@ class LeGrad(_CAM):
         self.hook_a[idx] = scores
         self._token_counts[idx] = output.shape[1]
 
-    def _precheck(self, class_idx: int | list[int], scores: Tensor | None = None) -> None:
-        super()._precheck(class_idx, scores)
+    def _precheck(
+        self,
+        class_idx: int | list[int] | None,
+        scores: Any = None,
+        targets: OutputTarget | list[OutputTarget] | None = None,
+    ) -> None:
+        super()._precheck(class_idx, scores, targets)
         if any(not isinstance(attention, Tensor) for attention in self.hook_attn):
             raise AssertionError("Inputs need to be forwarded through every LeGrad target block")
 
@@ -793,10 +790,12 @@ class LeGrad(_CAM):
 
     def compute_cams(
         self,
-        class_idx: int | list[int],
-        scores: Tensor | None = None,
+        class_idx: int | list[int] | None = None,
+        scores: Any = None,
         normalized: bool = True,
         retain_graph: bool = False,
+        *,
+        targets: OutputTarget | list[OutputTarget] | None = None,
         **kwargs: Any,
     ) -> list[Tensor]:
         """Compute and average layerwise positive attention-gradient maps.
@@ -804,7 +803,9 @@ class LeGrad(_CAM):
         Raises:
             ValueError: if attention and token shapes are incompatible
         """  # noqa: DOC201
-        relevances = self._get_weights(class_idx, scores, retain_graph=retain_graph, **kwargs)
+        if targets is not None:
+            raise ValueError("LeGrad does not support arbitrary output targets")
+        relevances = self._get_weights(cast(int | list[int], class_idx), scores, retain_graph=retain_graph, **kwargs)
         maps: list[Tensor] = []
         for idx, relevance in enumerate(relevances):
             token_count = self._token_counts[idx]
@@ -862,26 +863,30 @@ class RefineCAM(_CAMWrapper):
 
     def __call__(
         self,
-        class_idx: int | list[int],
-        scores: Tensor | None = None,
+        class_idx: int | list[int] | None = None,
+        scores: Any = None,
         normalized: bool = True,
         target_shape: tuple[int, ...] | None = None,
+        *,
+        targets: OutputTarget | list[OutputTarget] | None = None,
         **kwargs: Any,
     ) -> list[Tensor]:
         """Compute and refine the per-layer CAMs for an output class."""  # noqa: DOC201
-        cams = self.base_cam(class_idx, scores, normalized=True, **kwargs)
+        cams = self.base_cam(class_idx, scores, normalized=True, targets=targets, **kwargs)
         return [self.fuse_cams(cams, target_shape, normalized)]
 
     def compute_cams(
         self,
-        class_idx: int | list[int],
-        scores: Tensor | None = None,
+        class_idx: int | list[int] | None = None,
+        scores: Any = None,
         normalized: bool = True,
         target_shape: tuple[int, ...] | None = None,
+        *,
+        targets: OutputTarget | list[OutputTarget] | None = None,
         **kwargs: Any,
     ) -> list[Tensor]:
         """Compute and refine CAMs without the base extractor precheck."""  # noqa: DOC201
-        cams = self.base_cam.compute_cams(class_idx, scores, normalized=True, **kwargs)
+        cams = self.base_cam.compute_cams(class_idx, scores, normalized=True, targets=targets, **kwargs)
         return [self.fuse_cams(cams, target_shape, normalized)]
 
     @staticmethod

--- a/torchcam/metrics.py
+++ b/torchcam/metrics.py
@@ -84,6 +84,26 @@ def _get_cam(
     return cam_extractor.fuse_cams(cams), target_indices
 
 
+def _select_scores(
+    scores: Any,
+    target_indices: torch.Tensor | None,
+    targets: list[OutputTarget] | None,
+) -> torch.Tensor:
+    if targets is not None:
+        return _target_scores(scores, targets)
+    return cast(torch.Tensor, scores).gather(1, cast(torch.Tensor, target_indices).unsqueeze(1)).squeeze(1)
+
+
+def _filter_selection(
+    target_indices: torch.Tensor | None,
+    targets: list[OutputTarget] | None,
+    valid: torch.Tensor,
+) -> tuple[torch.Tensor | None, list[OutputTarget] | None]:
+    if targets is not None:
+        return None, [target for target, keep in zip(targets, valid, strict=True) if keep]
+    return cast(torch.Tensor, target_indices)[valid], None
+
+
 def _resize_cam(cam: torch.Tensor, spatial_shape: tuple[int, ...]) -> torch.Tensor:
     interpolation_mode = {1: "linear", 2: "bilinear", 3: "trilinear"}.get(len(spatial_shape))
     if interpolation_mode is None:
@@ -183,21 +203,12 @@ class ClassificationMetric:
 
             cam = _resize_cam(cam[~discard], tuple(input_tensor.shape[2:]))
             valid_input = input_tensor[~discard]
-            if target_fns is None:
-                valid_indices = cast(torch.Tensor, target_indices)[~discard]
-                selected_scores = scores[~discard].gather(1, valid_indices.unsqueeze(1)).squeeze(1)
-                valid_targets = None
-            else:
-                valid_indices = None
-                selected_scores = _target_scores(scores, target_fns)[~discard]
-                valid_targets = [target for target, valid in zip(target_fns, ~discard, strict=True) if valid]
+            selected_scores = _select_scores(scores, target_indices, target_fns)[~discard]
+            valid_indices, valid_targets = _filter_selection(target_indices, target_fns, ~discard)
 
             with self.cam_extractor._hooks_off(), torch.inference_mode():  # noqa: SLF001
                 masked_scores = _get_scores(self.cam_extractor, self.logits_fn, cam.unsqueeze(1) * valid_input)
-            if valid_targets is None:
-                masked_scores = masked_scores.gather(1, cast(torch.Tensor, valid_indices).unsqueeze(1)).squeeze(1)
-            else:
-                masked_scores = _target_scores(masked_scores, valid_targets)
+            masked_scores = _select_scores(masked_scores, valid_indices, valid_targets)
             drop = torch.relu(selected_scores - masked_scores).div(selected_scores + 1e-7)
             increase = selected_scores < masked_scores
 
@@ -349,12 +360,11 @@ class DeletionInsertionMetric:
                 perturbed_scores = _get_scores(self.cam_extractor, self.logits_fn, perturbed)
                 if targets is None:
                     indices = cast(torch.Tensor, target_indices)[sample_indices]
-                    selected_scores = perturbed_scores.gather(1, indices.unsqueeze(1)).squeeze(1)
+                    selected_targets = None
                 else:
-                    selected_scores = _target_scores(
-                        perturbed_scores,
-                        [targets[idx] for idx in sample_indices.tolist()],
-                    )
+                    indices = None
+                    selected_targets = [targets[idx] for idx in sample_indices.tolist()]
+                selected_scores = _select_scores(perturbed_scores, indices, selected_targets)
 
                 for score, job in zip(selected_scores, chunk, strict=True):
                     if job[1] == 0:
@@ -400,14 +410,8 @@ class DeletionInsertionMetric:
                 baseline = self._get_baseline(input_tensor)[~discard]
             valid_input = input_tensor[~discard]
             cam = _resize_cam(cam[~discard], tuple(input_tensor.shape[2:]))
-            if target_fns is None:
-                valid_indices = cast(torch.Tensor, target_indices)[~discard]
-                original_scores = scores[~discard].gather(1, valid_indices.unsqueeze(1)).squeeze(1).detach()
-                valid_targets = None
-            else:
-                valid_indices = None
-                original_scores = _target_scores(scores, target_fns)[~discard].detach()
-                valid_targets = [target for target, valid in zip(target_fns, ~discard, strict=True) if valid]
+            original_scores = _select_scores(scores, target_indices, target_fns)[~discard].detach()
+            valid_indices, valid_targets = _filter_selection(target_indices, target_fns, ~discard)
             order = torch.argsort(cam.flatten(1), dim=1, descending=True, stable=True)
             ranks = torch.argsort(order, dim=1)
             fractions, deletion, insertion = self._compute_curves(

--- a/torchcam/metrics.py
+++ b/torchcam/metrics.py
@@ -9,15 +9,19 @@ from typing import Any, Protocol, cast
 
 import torch
 
+from .methods.core import OutputTarget, _resolve_targets, _target_scores
+
 
 class _CAMExtractor(Protocol):
     model: torch.nn.Module
 
     def __call__(
         self,
-        class_idx: int | list[int],
-        scores: torch.Tensor | None = None,
+        class_idx: int | list[int] | None = None,
+        scores: Any = None,
         normalized: bool = True,
+        *,
+        targets: OutputTarget | list[OutputTarget] | None = None,
         **kwargs: Any,
     ) -> list[torch.Tensor]: ...
 
@@ -39,11 +43,11 @@ def _model_eval(model: torch.nn.Module) -> Iterator[None]:
 
 def _get_scores(
     cam_extractor: _CAMExtractor,
-    logits_fn: Callable[[torch.Tensor], torch.Tensor] | None,
+    logits_fn: Callable[[Any], Any] | None,
     input_tensor: torch.Tensor,
-) -> torch.Tensor:
+) -> Any:
     logits = cam_extractor.model(input_tensor)
-    return cast(torch.Tensor, logits if logits_fn is None else logits_fn(logits))
+    return logits if logits_fn is None else logits_fn(logits)
 
 
 def _resolve_class_idx(scores: torch.Tensor, class_idx: int | list[int] | None) -> tuple[int | list[int], torch.Tensor]:
@@ -68,9 +72,13 @@ def _resolve_class_idx(scores: torch.Tensor, class_idx: int | list[int] | None) 
 
 def _get_cam(
     cam_extractor: _CAMExtractor,
-    scores: torch.Tensor,
+    scores: Any,
     class_idx: int | list[int] | None,
-) -> tuple[torch.Tensor, torch.Tensor]:
+    targets: OutputTarget | list[OutputTarget] | None = None,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    if targets is not None:
+        cams = cam_extractor(scores=scores, targets=targets)
+        return cam_extractor.fuse_cams(cams), None
     extractor_idx, target_indices = _resolve_class_idx(scores, class_idx)
     cams = cam_extractor(extractor_idx, scores)
     return cam_extractor.fuse_cams(cams), target_indices
@@ -138,7 +146,7 @@ class ClassificationMetric:
     def __init__(
         self,
         cam_extractor: _CAMExtractor,
-        logits_fn: Callable[[torch.Tensor], torch.Tensor] | None = None,
+        logits_fn: Callable[[Any], Any] | None = None,
     ) -> None:
         self.cam_extractor = cam_extractor
         self.logits_fn = logits_fn
@@ -148,32 +156,50 @@ class ClassificationMetric:
         self,
         input_tensor: torch.Tensor,
         class_idx: int | list[int] | None = None,
+        *,
+        targets: OutputTarget | list[OutputTarget] | None = None,
     ) -> None:
         """Update the state of the metric with new predictions.
 
         Args:
             input_tensor: preprocessed input tensor for the model
             class_idx: class index to focus on (default: index of the top predicted class for each sample)
+            targets: scalar output target shared by the batch, or one target per sample
+
+        Raises:
+            ValueError: if both class indices and output targets are provided
         """
+        if targets is not None and class_idx is not None:
+            raise ValueError("provide either class_idx or targets, not both")
         with _model_eval(self.cam_extractor.model):
             scores = _get_scores(self.cam_extractor, self.logits_fn, input_tensor)
-            cam, target_indices = _get_cam(self.cam_extractor, scores, class_idx)
+            target_fns = _resolve_targets(targets, input_tensor.shape[0]) if targets is not None else None
+            cam, target_indices = _get_cam(self.cam_extractor, scores, class_idx, target_fns)
             discard = torch.isnan(cam).reshape(input_tensor.shape[0], -1).any(dim=-1)
-            nan_count = discard.sum().item()
+            nan_count = int(discard.sum().item())
             if discard.all():
                 self.nan_count += nan_count
                 return
 
             cam = _resize_cam(cam[~discard], tuple(input_tensor.shape[2:]))
-            scores = scores[~discard].gather(1, target_indices[~discard].unsqueeze(1)).squeeze(1)
-            target_indices = target_indices[~discard]
             valid_input = input_tensor[~discard]
+            if target_fns is None:
+                valid_indices = cast(torch.Tensor, target_indices)[~discard]
+                selected_scores = scores[~discard].gather(1, valid_indices.unsqueeze(1)).squeeze(1)
+                valid_targets = None
+            else:
+                valid_indices = None
+                selected_scores = _target_scores(scores, target_fns)[~discard]
+                valid_targets = [target for target, valid in zip(target_fns, ~discard, strict=True) if valid]
 
             with self.cam_extractor._hooks_off(), torch.inference_mode():  # noqa: SLF001
                 masked_scores = _get_scores(self.cam_extractor, self.logits_fn, cam.unsqueeze(1) * valid_input)
-            masked_scores = masked_scores.gather(1, target_indices.unsqueeze(1)).squeeze(1)
-            drop = torch.relu(scores - masked_scores).div(scores + 1e-7)
-            increase = scores < masked_scores
+            if valid_targets is None:
+                masked_scores = masked_scores.gather(1, cast(torch.Tensor, valid_indices).unsqueeze(1)).squeeze(1)
+            else:
+                masked_scores = _target_scores(masked_scores, valid_targets)
+            drop = torch.relu(selected_scores - masked_scores).div(selected_scores + 1e-7)
+            increase = selected_scores < masked_scores
 
         self.drop += drop.sum().item()
         self.increase += increase.sum().item()
@@ -238,7 +264,7 @@ class DeletionInsertionMetric:
     def __init__(
         self,
         cam_extractor: _CAMExtractor,
-        logits_fn: Callable[[torch.Tensor], torch.Tensor] | None = None,
+        logits_fn: Callable[[Any], Any] | None = None,
         *,
         steps: int = 20,
         baseline: torch.Tensor | Callable[[torch.Tensor], torch.Tensor] | None = None,
@@ -276,13 +302,14 @@ class DeletionInsertionMetric:
         except RuntimeError as exc:
             raise ValueError("baseline must be broadcastable to the input shape") from exc
 
-    def _compute_curves(
+    def _compute_curves(  # noqa: PLR0914
         self,
         input_tensor: torch.Tensor,
         baseline: torch.Tensor,
         ranks: torch.Tensor,
-        target_indices: torch.Tensor,
+        target_indices: torch.Tensor | None,
         original_scores: torch.Tensor,
+        targets: list[OutputTarget] | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         num_positions = ranks.shape[1]
         step_size = (num_positions + self.steps - 1) // self.steps
@@ -319,11 +346,15 @@ class DeletionInsertionMetric:
                     input_tensor.flatten(2)[sample_indices],
                     baseline.flatten(2)[sample_indices],
                 ).reshape((-1, *input_tensor.shape[1:]))
-                selected_scores = (
-                    _get_scores(self.cam_extractor, self.logits_fn, perturbed)
-                    .gather(1, target_indices[sample_indices].unsqueeze(1))
-                    .squeeze(1)
-                )
+                perturbed_scores = _get_scores(self.cam_extractor, self.logits_fn, perturbed)
+                if targets is None:
+                    indices = cast(torch.Tensor, target_indices)[sample_indices]
+                    selected_scores = perturbed_scores.gather(1, indices.unsqueeze(1)).squeeze(1)
+                else:
+                    selected_scores = _target_scores(
+                        perturbed_scores,
+                        [targets[idx] for idx in sample_indices.tolist()],
+                    )
 
                 for score, job in zip(selected_scores, chunk, strict=True):
                     if job[1] == 0:
@@ -336,22 +367,31 @@ class DeletionInsertionMetric:
 
         return fractions, deletion, insertion
 
-    def update(
+    def update(  # noqa: PLR0914
         self,
         input_tensor: torch.Tensor,
         class_idx: int | list[int] | None = None,
+        *,
+        targets: OutputTarget | list[OutputTarget] | None = None,
     ) -> None:
         """Update the metric with a batch of inputs.
 
         Args:
             input_tensor: preprocessed model input
             class_idx: shared class index, one class index per sample, or ``None`` to use original top predictions
+            targets: scalar output target shared by the batch, or one target per sample
+
+        Raises:
+            ValueError: if both class indices and output targets are provided
         """
+        if targets is not None and class_idx is not None:
+            raise ValueError("provide either class_idx or targets, not both")
         with _model_eval(self.cam_extractor.model):
             scores = _get_scores(self.cam_extractor, self.logits_fn, input_tensor)
-            cam, target_indices = _get_cam(self.cam_extractor, scores, class_idx)
+            target_fns = _resolve_targets(targets, input_tensor.shape[0]) if targets is not None else None
+            cam, target_indices = _get_cam(self.cam_extractor, scores, class_idx, target_fns)
             discard = torch.isnan(cam).reshape(input_tensor.shape[0], -1).any(dim=-1)
-            nan_count = discard.sum().item()
+            nan_count = int(discard.sum().item())
             if discard.all():
                 self.nan_count += nan_count
                 return
@@ -360,16 +400,23 @@ class DeletionInsertionMetric:
                 baseline = self._get_baseline(input_tensor)[~discard]
             valid_input = input_tensor[~discard]
             cam = _resize_cam(cam[~discard], tuple(input_tensor.shape[2:]))
-            target_indices = target_indices[~discard]
-            original_scores = scores[~discard].gather(1, target_indices.unsqueeze(1)).squeeze(1).detach()
+            if target_fns is None:
+                valid_indices = cast(torch.Tensor, target_indices)[~discard]
+                original_scores = scores[~discard].gather(1, valid_indices.unsqueeze(1)).squeeze(1).detach()
+                valid_targets = None
+            else:
+                valid_indices = None
+                original_scores = _target_scores(scores, target_fns)[~discard].detach()
+                valid_targets = [target for target, valid in zip(target_fns, ~discard, strict=True) if valid]
             order = torch.argsort(cam.flatten(1), dim=1, descending=True, stable=True)
             ranks = torch.argsort(order, dim=1)
             fractions, deletion, insertion = self._compute_curves(
                 valid_input,
                 baseline,
                 ranks,
-                target_indices,
+                valid_indices,
                 original_scores,
+                valid_targets,
             )
             deletion_auc = torch.trapezoid(deletion, fractions, dim=1)
             insertion_auc = torch.trapezoid(insertion, fractions, dim=1)


### PR DESCRIPTION
## What
- add a public `OutputTarget` callable contract for batched tensor and per-sample list outputs
- support shared or per-sample targets in gradient CAMs, ScoreCAM/SSCAM/ISCAM, RefineCAM, and both metrics
- compute gradient CAM derivatives with `torch.autograd.grad` so CAM extraction preserves existing parameter gradients
- document segmentation, embedding, structured-output, and metric batching usage

`CAM`, `FinerCAM`, and `LeGrad` keep their specialized class-based objectives.

## Why
This gives detection, segmentation, embedding, and other structured-output models one narrow scalar-target seam instead of task-specific adapters.

## Rebased onto current main
Rebased onto `5966a57` after PRs #423–#426 merged.

The only functional overlap was PR #425's ScoreCAM masked-input memory work. This branch now keeps #425's reusable chunk buffers and adds only scalar target selection on top. CI, dependency modernization, latency timing, overlay performance, and lazy root imports remain entirely inherited from main.

## Concrete result
For a segmentation output shaped `(batch, classes, height, width)`, explain class 0 inside the top-left 2×2 region:

```python
with LayerCAM(model, "features") as extractor:
    output = model(image)  # (1, 2, 4, 4)
    cam = extractor(
        scores=output,
        targets=lambda sample: sample[0, :2, :2].mean(),
    )[0]
```

Actual deterministic output:

```text
CAM shape: (1, 4, 4)
tensor([[0.2500, 0.5000, 0.0000, 0.0000],
        [0.7500, 1.0000, 0.0000, 0.0000],
        [0.0000, 0.0000, 0.0000, 0.0000],
        [0.0000, 0.0000, 0.0000, 0.0000]])
parameter gradients preserved: True
```

The target callable reduces one sample's structured output to the scalar to explain; TorchCAM returns one normalized spatial CAM per target layer.

## Adversarial review follow-up
Six independent headless reviews were requested. Five completed substantive reviews and approved the core design; one hung during environment setup and produced no findings.

Applied the highest-ROI corrections:
- reject ambiguous tuple outputs and document the thin-wrapper path
- centralize repeated score selection in ScoreCAM variants and metrics
- report disconnected target-layer gradients explicitly
- reject arbitrary targets explicitly in specialized extractors
- add SmoothGradCAMpp, target-validation, unsupported-method, and error-path tests
- clarify ScoreCAM and metric re-forward behavior

## Validation
- `ruff format --check .`
- `ruff check .`
- `ty check`
- `pytest -q` — 231 passed, 2 skipped, 99% coverage

Validation used a fresh Python 3.11 environment because this desktop defaults to a free-threaded Python 3.14 build that cannot compile one pinned test dependency.