### PR TITLE
perf: defer root imports and speed up overlays

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -9,58 +9,35 @@ import torchcam
 _PUBLIC_MODULES = ("explain", "methods", "metrics", "utils")
 
 
-def _run_in_fresh_process(statement: str) -> None:
+def test_lazy_imports_in_fresh_process() -> None:
     script = f"""
 import sys
 import torchcam
 
-module_names = {(_PUBLIC_MODULES)!r}
+names = {_PUBLIC_MODULES!r}
 assert "torch" not in sys.modules
 assert "matplotlib.pyplot" not in sys.modules
-assert all(f"torchcam.{{name}}" not in sys.modules for name in module_names)
-assert all(name not in vars(torchcam) for name in module_names)
+assert all(f"torchcam.{{name}}" not in sys.modules for name in names)
+assert all(name not in vars(torchcam) for name in names)
 assert torchcam.__version__
 
-{statement}
-"""
-    subprocess.run([sys.executable, "-c", script], check=True)  # noqa: S603
-
-
-def test_bare_import_is_lazy() -> None:
-    _run_in_fresh_process("")
-
-
-@pytest.mark.parametrize("module_name", _PUBLIC_MODULES)
-def test_lazy_module_in_fresh_process(module_name: str) -> None:
-    _run_in_fresh_process(
-        f"""
-module = getattr(torchcam, {module_name!r})
-assert module.__name__ == "torchcam.{module_name}"
-assert module is getattr(torchcam, {module_name!r})
-assert module is sys.modules["torchcam.{module_name}"]
-"""
-    )
-
-
-def test_from_import_syntax() -> None:
-    _run_in_fresh_process(
-        """
+from torchcam import *
 from torchcam import explain, methods, metrics, utils
 
-assert explain is sys.modules["torchcam.explain"]
-assert methods is sys.modules["torchcam.methods"]
-assert metrics is sys.modules["torchcam.metrics"]
-assert utils is sys.modules["torchcam.utils"]
+modules = (explain, methods, metrics, utils)
+assert modules == (torchcam.explain, torchcam.methods, torchcam.metrics, torchcam.utils)
+assert all(module is getattr(torchcam, name) for name, module in zip(names, modules))
+assert all(module is sys.modules[f"torchcam.{{name}}"] for name, module in zip(names, modules))
+assert version is torchcam.version
+assert "matplotlib.pyplot" not in sys.modules
 """
-    )
+    subprocess.run([sys.executable, "-c", script], check=True)  # noqa: S603
 
 
 @pytest.mark.parametrize("module_name", _PUBLIC_MODULES)
 def test_lazy_module_is_cached(module_name: str, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delattr(torchcam, module_name, raising=False)
-
     module = getattr(torchcam, module_name)
-
     assert module is getattr(torchcam, module_name)
     assert module is sys.modules[f"torchcam.{module_name}"]
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,75 @@
+import importlib.metadata
+import subprocess  # noqa: S404
+import sys
+
+import pytest
+
+import torchcam
+
+_PUBLIC_MODULES = ("explain", "methods", "metrics", "utils")
+
+
+def _run_in_fresh_process(statement: str) -> None:
+    script = f"""
+import sys
+import torchcam
+
+module_names = {(_PUBLIC_MODULES)!r}
+assert "torch" not in sys.modules
+assert "matplotlib.pyplot" not in sys.modules
+assert all(f"torchcam.{{name}}" not in sys.modules for name in module_names)
+assert all(name not in vars(torchcam) for name in module_names)
+assert torchcam.__version__
+
+{statement}
+"""
+    subprocess.run([sys.executable, "-c", script], check=True)  # noqa: S603
+
+
+def test_bare_import_is_lazy() -> None:
+    _run_in_fresh_process("")
+
+
+@pytest.mark.parametrize("module_name", _PUBLIC_MODULES)
+def test_lazy_module_in_fresh_process(module_name: str) -> None:
+    _run_in_fresh_process(
+        f"""
+module = getattr(torchcam, {module_name!r})
+assert module.__name__ == "torchcam.{module_name}"
+assert module is getattr(torchcam, {module_name!r})
+assert module is sys.modules["torchcam.{module_name}"]
+"""
+    )
+
+
+def test_from_import_syntax() -> None:
+    _run_in_fresh_process(
+        """
+from torchcam import explain, methods, metrics, utils
+
+assert explain is sys.modules["torchcam.explain"]
+assert methods is sys.modules["torchcam.methods"]
+assert metrics is sys.modules["torchcam.metrics"]
+assert utils is sys.modules["torchcam.utils"]
+"""
+    )
+
+
+@pytest.mark.parametrize("module_name", _PUBLIC_MODULES)
+def test_lazy_module_is_cached(module_name: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delattr(torchcam, module_name, raising=False)
+
+    module = getattr(torchcam, module_name)
+
+    assert module is getattr(torchcam, module_name)
+    assert module is sys.modules[f"torchcam.{module_name}"]
+
+
+def test_package_version() -> None:
+    assert torchcam.__version__ == importlib.metadata.version("torchcam")
+    assert torchcam.version is importlib.metadata.version
+
+
+def test_unknown_attribute() -> None:
+    with pytest.raises(AttributeError, match="module 'torchcam' has no attribute 'missing'"):
+        _ = torchcam.missing  # type: ignore[attr-defined]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,27 +1,99 @@
 import numpy as np
+import pytest
+from matplotlib import colormaps
+from matplotlib.colors import Colormap, ListedColormap
 from PIL import Image
+from PIL.Image import Resampling
 
 from torchcam import utils
 
 
-def test_overlay_mask():
-    # RGB image
-    img = Image.fromarray(np.zeros((4, 4, 3)).astype(np.uint8))
-    mask = Image.fromarray(255 * np.ones((4, 4)).astype(np.uint8))
-    overlayed = utils.overlay_mask(img, mask, alpha=0.7)
+def _legacy_overlay_mask(
+    img: Image.Image, mask: Image.Image, colormap: Colormap | str = "jet", alpha: float = 0.7
+) -> Image.Image:
+    cmap = colormaps.get_cmap(colormap)
+    overlay = mask.resize(img.size, resample=Resampling.BICUBIC)
+    overlay = (255 * cmap(np.asarray(overlay) ** 2)[:, :, :3]).astype(np.uint8)
+    bg_img = np.asarray(img) if len(img.getbands()) == 3 else np.asarray(img)[..., np.newaxis].repeat(3, axis=-1)
+    return Image.fromarray((alpha * bg_img + (1 - alpha) * overlay).astype(np.uint8))
 
-    # Check object type
-    assert isinstance(overlayed, Image.Image)
-    # Verify value
-    assert np.all(np.asarray(overlayed)[..., 0] == 0)
-    assert np.all(np.asarray(overlayed)[..., 1] == 0)
-    assert np.all(np.asarray(overlayed)[..., 2] == 39)
 
-    # grayscale image
-    img = Image.fromarray(np.zeros((4, 4)).astype(np.uint8))
-    overlayed = utils.overlay_mask(img, mask, alpha=0.7)
+@pytest.mark.parametrize("shape", [(4, 4), (4, 4, 3)])
+def test_overlay_mask(shape: tuple[int, ...]):
+    img = Image.fromarray(np.zeros(shape, dtype=np.uint8))
+    mask = Image.fromarray(np.full((4, 4), 255, dtype=np.uint8))
 
-    # Verify value
-    assert np.all(np.asarray(overlayed)[..., 0] == 0)
-    assert np.all(np.asarray(overlayed)[..., 1] == 0)
-    assert np.all(np.asarray(overlayed)[..., 2] == 39)
+    actual = utils.overlay_mask(img, mask, alpha=0.7)
+    expected = np.zeros((4, 4, 3), dtype=np.uint8)
+    expected[..., 2] = 39
+
+    assert isinstance(actual, Image.Image)
+    np.testing.assert_array_equal(np.asarray(actual), expected)
+
+
+@pytest.mark.parametrize("shape", [(7, 9), (7, 9, 3)])
+@pytest.mark.parametrize("alpha", [0.0, 0.5, 0.999])
+@pytest.mark.parametrize("colormap", ["jet", pytest.param(ListedColormap(["black", "red", "white"]), id="custom")])
+def test_overlay_mask_parity(shape: tuple[int, ...], alpha: float, colormap: Colormap | str):
+    rng = np.random.default_rng(0)
+    img = Image.fromarray(rng.integers(0, 256, shape, dtype=np.uint8))
+    mask = Image.fromarray(rng.integers(0, 256, (4, 5), dtype=np.uint8))
+
+    expected = np.asarray(_legacy_overlay_mask(img, mask, colormap, alpha))
+    actual = utils.overlay_mask(img, mask, colormap, alpha)
+    difference = np.abs(expected.astype(np.int16) - np.asarray(actual).astype(np.int16))
+
+    assert actual.mode == "RGB"
+    assert actual.size == img.size
+    assert np.asarray(actual).dtype == np.uint8
+    assert difference.max() <= 1
+
+
+@pytest.mark.parametrize(("mode", "shape"), [("P", (5, 6)), ("HSV", (5, 6, 3))])
+def test_overlay_mask_preserves_raw_band_modes(mode: str, shape: tuple[int, ...]):
+    values = np.arange(np.prod(shape), dtype=np.uint8).reshape(shape)
+    img = Image.frombytes(mode, (shape[1], shape[0]), values.tobytes())
+    mask = Image.fromarray(np.arange(12, dtype=np.uint8).reshape(3, 4))
+
+    expected = np.asarray(_legacy_overlay_mask(img, mask))
+    actual = np.asarray(utils.overlay_mask(img, mask))
+
+    assert np.abs(expected.astype(np.int16) - actual.astype(np.int16)).max() <= 1
+
+
+def test_overlay_mask_preserves_nan_alpha():
+    img = Image.fromarray(np.arange(60, dtype=np.uint8).reshape(4, 5, 3))
+    mask = Image.fromarray(np.arange(20, dtype=np.uint8).reshape(4, 5))
+
+    with pytest.warns(RuntimeWarning):
+        expected = np.asarray(_legacy_overlay_mask(img, mask, alpha=float("nan")))
+    with pytest.warns(RuntimeWarning):
+        actual = np.asarray(utils.overlay_mask(img, mask, alpha=float("nan")))
+
+    np.testing.assert_array_equal(actual, expected)
+
+
+def test_overlay_mask_errors():
+    img = Image.new("RGB", (4, 4))
+    mask = Image.new("L", (4, 4))
+
+    with pytest.raises(TypeError, match=r"img and mask arguments need to be PIL\.Image"):
+        utils.overlay_mask(np.zeros((4, 4, 3)), mask)  # ty: ignore[invalid-argument-type]
+    with pytest.raises(TypeError, match=r"img and mask arguments need to be PIL\.Image"):
+        utils.overlay_mask(img, np.zeros((4, 4)))  # ty: ignore[invalid-argument-type]
+    with pytest.raises(ValueError):
+        utils.overlay_mask(img, Image.new("RGB", (4, 4)))
+    with pytest.raises(ValueError, match="img argument needs to be a grayscale or RGB image"):
+        utils.overlay_mask(Image.new("RGBA", (4, 4)), mask)
+    with pytest.raises(ValueError):
+        utils.overlay_mask(img, mask, colormap="missing")
+
+
+@pytest.mark.parametrize("alpha", [0, -0.1, 1.0, "0.5", None])
+def test_overlay_mask_invalid_alpha(alpha: object):
+    with pytest.raises(ValueError, match="alpha argument is expected to be of type float between 0 and 1"):
+        utils.overlay_mask(
+            Image.new("RGB", (4, 4)),
+            Image.new("L", (4, 4)),
+            alpha=alpha,  # ty: ignore[invalid-argument-type]
+        )

--- a/torchcam/__init__.py
+++ b/torchcam/__init__.py
@@ -1,4 +1,13 @@
+from importlib import import_module as _import_module
 from importlib.metadata import version
-from torchcam import explain, methods, metrics, utils
+from types import ModuleType as _ModuleType
 
 __version__ = version("torchcam")
+
+
+def __getattr__(name: str) -> _ModuleType:
+    if name in {"explain", "methods", "metrics", "utils"}:
+        module = _import_module(f"{__name__}.{name}")
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/torchcam/__init__.py
+++ b/torchcam/__init__.py
@@ -2,6 +2,8 @@ from importlib import import_module as _import_module
 from importlib.metadata import version
 from types import ModuleType as _ModuleType
 
+__all__ = ("explain", "methods", "metrics", "utils", "version")  # noqa: F822
+
 __version__ = version("torchcam")
 
 

--- a/torchcam/utils.py
+++ b/torchcam/utils.py
@@ -4,9 +4,9 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 
 import numpy as np
+from matplotlib import colormaps
 from matplotlib.colors import Colormap
-from matplotlib.pyplot import get_cmap
-from PIL.Image import Image, Resampling, fromarray
+from PIL.Image import Image, Resampling, blend, fromarray
 
 
 def overlay_mask(img: Image, mask: Image, colormap: Colormap | str = "jet", alpha: float = 0.7) -> Image:
@@ -44,10 +44,12 @@ def overlay_mask(img: Image, mask: Image, colormap: Colormap | str = "jet", alph
     if len(img.getbands()) not in {1, 3}:
         raise ValueError("img argument needs to be a grayscale or RGB image")
 
-    cmap = get_cmap(colormap)
+    cmap = colormaps.get_cmap(colormap)
     # Resize mask and apply colormap
     overlay = mask.resize(img.size, resample=Resampling.BICUBIC)
-    overlay = (255 * cmap(np.asarray(overlay) ** 2)[:, :, :3]).astype(np.uint8)
+    overlay = cmap(np.asarray(overlay) ** 2, bytes=True)[:, :, :3]
+    if img.mode in {"L", "RGB"} and overlay.ndim == 3 and np.isfinite(alpha):
+        return blend(fromarray(overlay), img.convert("RGB"), alpha)
     # Overlay the image with the mask
     bg_img = np.asarray(img) if len(img.getbands()) == 3 else np.asarray(img)[..., np.newaxis].repeat(3, axis=-1)
     return fromarray((alpha * bg_img + (1 - alpha) * overlay).astype(np.uint8))


### PR DESCRIPTION
## Summary

- defer the four public root submodules with module-level `__getattr__`, caching the imported module in `globals()`
- preserve the legacy direct, explicit, and star-import surfaces, including the existing public `version` helper
- replace pyplot colormap lookup and the common NumPy blend with `matplotlib.colormaps`, `bytes=True`, and Pillow blending
- retain the NumPy path for currently accepted nonstandard band modes, non-grayscale masks, and NaN alpha so validation, raw-band behavior, and exception types stay compatible

This improves package startup and overlay rendering. It does **not** make CAM inference itself faster.

Base: `b7f10ddb33acb452d5d89af410a2e6792eb1d510`

## Import benchmark

Apple M3 Pro, macOS 15.7.7, arm64, Python 3.11.13, Torch 2.13.0. Each value is a fresh Python process.

| Measurement | Samples (ms) | Median (Q1–Q3) |
|---|---|---:|
| eager bare `import torchcam` | 3564.893, 3424.076, 3770.539, 4129.868, 3568.176, 3332.565, 3086.285, 4167.411, 3454.808 | 3564.893 (3424.076–3770.539) |
| lazy bare `import torchcam` | 27.461, 23.487, 39.241, 24.500, 48.628, 28.293, 25.467, 22.543, 27.014 | 27.014 (24.500–28.293) |
| first lazy `torchcam.methods` access | 3026.112, 2231.906, 3985.248, 2549.559, 3089.068, 2388.335, 2399.506, 2431.719, 2702.453 | 2549.559 (2399.506–3026.112) |

All nine lazy bare-import processes had no `torch`, `matplotlib.pyplot`, `torchcam.explain`, `torchcam.methods`, `torchcam.metrics`, or `torchcam.utils` entry before access. All nine loaded Torch when `torchcam.methods` was first accessed. The real Torch cost is deferred, not hidden.

## Overlay benchmark and parity

Python 3.11.13, NumPy 1.26.4, Pillow 12.3.0, Matplotlib 3.11.1. Fixed RNG seed `0`; three warmups; seven samples. Each 224 sample contains 100 calls and each 1024 sample contains 20 calls. The table uses a same-process copy of the pre-change implementation to reduce machine-noise bias.

| Size | Legacy median | New median | Change | Max channel difference | Mean absolute difference |
|---|---:|---:|---:|---:|---:|
| 224×224 | 2.129 ms | 1.653 ms | -22.4% | 1 | 0.005999 |
| 1024×1024 | 41.470 ms | 26.904 ms | -35.1% | 1 | 0.005942 |

The independently recorded pre-edit medians were 2.475 ms and 69.058 ms; post-edit medians were 1.361 ms and 27.110 ms, so neither size regressed. The deterministic test suite enforces the one-level parity bound.

## Validation

- `rtk make test`: 198 passed, 2 skipped in 152.58 s; no warnings
- `torchcam/__init__.py`: 100% coverage
- `torchcam/utils.py`: 100% coverage
- `rtk make quality`: passed (Ruff lint/format, ty, dependency sync)
- `rtk git diff --check`: passed
- `rtk git diff origin/main...HEAD --check`: passed
- final branch worktree clean; source `1f22` worktree unchanged and clean

No dependency, lock, documentation, demo, public signature, or API-name changes.
