### PR TITLE
perf(methods): reduce ScoreCAM-family masked-input memory

### DIFF
--- a/demo/app.py
+++ b/demo/app.py
@@ -130,7 +130,7 @@ def preserve_model_state(model):
             parameter.requires_grad_(requires_grad)
 
 
-def build_extractor(model, method_name, target_layers, finer_gamma=0.6, finer_references=3):
+def build_extractor(model, method_name, target_layers, finer_gamma=0.6, finer_references=3, score_batch_size=32):
     if method_name == "CAM":
         # ponytail: supported torchvision models register the class-output Linear last; use explicit heads if that changes.
         fc_layer = next(
@@ -144,6 +144,8 @@ def build_extractor(model, method_name, target_layers, finer_gamma=0.6, finer_re
             gamma=finer_gamma,
             num_references=finer_references,
         )
+    if method_name in SLOW_METHODS:
+        return getattr(methods, method_name)(model, target_layer=target_layers, batch_size=score_batch_size)
     if method_name == "RefineCAM":
         return methods.RefineCAM(model, target_layer=target_layers)
     if method_name == "LeGrad":
@@ -160,6 +162,7 @@ def extract_cam(
     class_idx=None,
     finer_gamma=0.6,
     finer_references=3,
+    score_batch_size=32,
 ):
     unknown_layers = [layer for layer in target_layers if layer not in dict(model.named_modules())]
     if unknown_layers:
@@ -175,6 +178,7 @@ def extract_cam(
             target_layers,
             finer_gamma,
             finer_references,
+            score_batch_size,
         ) as extractor:
             scores = model(input_tensor.unsqueeze(0).to(device))
             target_idx = int(scores.argmax(dim=1).item()) if class_idx is None else class_idx
@@ -223,6 +227,7 @@ def compute_result(
     explicit_class_idx,
     finer_gamma,
     finer_references,
+    score_batch_size,
 ):
     target_layers = parse_target_layers(target_layer_value, model_name, method_name)
     input_tensor, model_input = preprocess_image(selected_image, weights)
@@ -245,6 +250,7 @@ def compute_result(
             explicit_class_idx,
             finer_gamma,
             int(finer_references),
+            int(score_batch_size),
         )
     raw_image = colorize_cam(cam)
     overlay_image = overlay_mask(
@@ -347,6 +353,7 @@ def main():
 
         finer_gamma = 0.6
         finer_references = 3
+        score_batch_size = 32
         preset = "+".join(target_layer_preset(model_name, method_name))
         with st.expander("Method settings"):
             target_layer_value = st.text_input(
@@ -363,6 +370,14 @@ def main():
                     max_value=len(categories) - 1,
                     value=3,
                     step=1,
+                )
+            if method_name in SLOW_METHODS:
+                score_batch_size = st.number_input(
+                    "Masked-input batch size",
+                    min_value=1,
+                    value=32,
+                    step=1,
+                    help="Lower values use less memory but may change extraction latency.",
                 )
 
         if method_name in SLOW_METHODS:
@@ -384,6 +399,7 @@ def main():
                 explicit_class_idx,
                 finer_gamma,
                 finer_references,
+                score_batch_size,
             )
         except ConnectionError as exc:
             LOGGER.exception("Unable to load pretrained model")

--- a/scripts/eval_latency.py
+++ b/scripts/eval_latency.py
@@ -100,7 +100,11 @@ def main(args):
     torch.manual_seed(0)
 
     weights = get_model_weights(args.arch).DEFAULT if args.weights == "default" else None
-    model = get_model(args.arch, weights=weights).eval().to(device=device)
+    if device.type == "mps":
+        with device:
+            model = get_model(args.arch, weights=weights).eval()
+    else:
+        model = get_model(args.arch, weights=weights).eval().to(device=device)
     model.requires_grad_(False)
 
     input_tensor = torch.rand((1, 3, args.size, args.size), device=device, requires_grad=True)

--- a/scripts/eval_latency.py
+++ b/scripts/eval_latency.py
@@ -16,70 +16,139 @@ from torchvision.models import get_model, get_model_weights
 
 from torchcam import methods
 
-
-def main(args):
-    if args.device is None:
-        args.device = "cuda:0" if torch.cuda.is_available() else "cpu"
-
-    device = torch.device(args.device)
-
-    # Pretrained imagenet model
-    weights = get_model_weights(args.arch).DEFAULT
-    model = get_model(args.arch, weights=weights).to(device=device)
-    # Freeze the model
-    for p in model.parameters():
-        p.requires_grad_(False)
-
-    # Input
-    img_tensor = torch.rand((1, 3, args.size, args.size)).to(device=device)
-    img_tensor.requires_grad_(True)
-
-    # Warmup
-    for _ in range(10):
-        with torch.no_grad():
-            _ = model(img_tensor)
-
-    timings = []
-
-    # Evaluation runs
-    with methods.__dict__[args.method](model) as cam_extractor:
-        for _ in range(args.it):
-            scores = model(img_tensor)
-
-            # Select the class index
-            class_idx = scores.squeeze(0).argmax().item() if args.class_idx is None else args.class_idx
-
-            # Use the hooked data to compute activation map
-            start_ts = time.perf_counter()
-            _ = cam_extractor(class_idx, scores)
-            timings.append(time.perf_counter() - start_ts)
-
-    timings_ = np.array(timings)
-    print(f"{args.method} w/ {args.arch} ({args.it} runs on ({args.size}, {args.size}) inputs)")
-    print(f"mean {1000 * timings_.mean():.2f}ms, std {1000 * timings_.std():.2f}ms")
+METHOD_NAMES = tuple(sorted(name for name, value in vars(methods).items() if isinstance(value, type)))
 
 
-if __name__ == "__main__":
+def _positive_int(value):
+    value = int(value)
+    if value <= 0:
+        raise argparse.ArgumentTypeError("expected a positive integer")
+    return value
+
+
+def _synchronize(device):
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+    elif device.type == "mps":
+        torch.mps.synchronize()
+
+
+def _time_sample(model, input_tensor, extractor, requested_class, device, scope, cam_kwargs):
+    model.zero_grad(set_to_none=True)
+    input_tensor.grad = None
+
+    if scope == "extractor":
+        scores = model(input_tensor)
+        class_idx = scores.squeeze(0).argmax().item() if requested_class is None else requested_class
+
+    _synchronize(device)
+    started_at = time.perf_counter()
+
+    if scope == "end-to-end":
+        scores = model(input_tensor)
+        class_idx = scores.squeeze(0).argmax().item() if requested_class is None else requested_class
+
+    cams = extractor(class_idx, scores, **cam_kwargs)
+    _synchronize(device)
+    elapsed = time.perf_counter() - started_at
+    return elapsed, cams
+
+
+def _validate_cams(cams, expected_shapes):
+    if not cams or any(
+        not isinstance(cam, torch.Tensor)
+        or cam.ndim < 3
+        or cam.shape[0] != 1
+        or cam.numel() == 0
+        or not torch.isfinite(cam).all().item()
+        for cam in cams
+    ):
+        raise RuntimeError("CAM extractor returned an invalid activation map")
+    shapes = tuple(tuple(cam.shape) for cam in cams)
+    if expected_shapes is not None and shapes != expected_shapes:
+        raise RuntimeError(f"CAM shapes changed across samples: expected {expected_shapes}, got {shapes}")
+    return shapes
+
+
+def _build_parser():
     parser = argparse.ArgumentParser(
         description="CAM method latency benchmark",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
-    parser.add_argument("method", type=str, help="CAM method to use")
-    parser.add_argument(
-        "--arch",
-        type=str,
-        default="resnet18",
-        help="Name of the torchvision architecture",
-    )
-    parser.add_argument("--size", type=int, default=224, help="The image input size")
+    parser.add_argument("method", choices=METHOD_NAMES, help="CAM method to use")
+    parser.add_argument("--arch", default="resnet18", help="Name of the torchvision architecture")
+    parser.add_argument("--size", type=_positive_int, default=224, help="The image input size")
     parser.add_argument("--class-idx", type=int, default=232, help="Index of the class to inspect")
+    parser.add_argument("--device", default=None, help="Device (auto-selects CUDA, otherwise CPU; pass mps explicitly)")
+    parser.add_argument("--it", type=_positive_int, default=100, help="Number of iterations to run")
     parser.add_argument(
-        "--device",
-        type=str,
-        default=None,
-        help="Default device to perform computation on",
+        "--scope", choices=("extractor", "end-to-end"), default="extractor", help="Region included in timing"
     )
-    parser.add_argument("--it", type=int, default=100, help="Number of iterations to run")
-    args = parser.parse_args()
+    parser.add_argument("--weights", choices=("default", "none"), default="default", help="Torchvision weights")
+    parser.add_argument(
+        "--batch-size",
+        type=_positive_int,
+        default=32,
+        help="Masked-input batch size for ScoreCAM-family methods",
+    )
+    parser.add_argument("--target-layer", action="append", help="Target layer name; repeat for multiple layers")
+    return parser
 
-    main(args)
+
+def main(args):
+    device = torch.device(args.device or ("cuda:0" if torch.cuda.is_available() else "cpu"))
+    torch.manual_seed(0)
+
+    weights = get_model_weights(args.arch).DEFAULT if args.weights == "default" else None
+    model = get_model(args.arch, weights=weights).eval().to(device=device)
+    model.requires_grad_(False)
+
+    input_tensor = torch.rand((1, 3, args.size, args.size), device=device, requires_grad=True)
+
+    for _ in range(10):
+        with torch.no_grad():
+            _ = model(input_tensor)
+        _synchronize(device)
+
+    extractor_cls = getattr(methods, args.method)
+    extractor_kwargs = (
+        {"target_layer": args.target_layer[0] if len(args.target_layer) == 1 else args.target_layer}
+        if args.target_layer
+        else {}
+    )
+    if issubclass(extractor_cls, methods.ScoreCAM):
+        extractor_kwargs["batch_size"] = args.batch_size
+
+    timings = []
+    expected_shapes = None
+    cam_kwargs = {"target_shape": tuple(input_tensor.shape[2:])} if extractor_cls is methods.RefineCAM else {}
+    with extractor_cls(model, **extractor_kwargs) as cam_extractor:
+        for _ in range(args.it):
+            elapsed, cams = _time_sample(
+                model,
+                input_tensor,
+                cam_extractor,
+                args.class_idx,
+                device,
+                args.scope,
+                cam_kwargs,
+            )
+            expected_shapes = _validate_cams(cams, expected_shapes)
+            timings.append(1000 * elapsed)
+
+    timings_ = np.asarray(timings)
+    q1, median, q3 = np.percentile(timings_, (25, 50, 75))
+    target_layers = ",".join(args.target_layer) if args.target_layer else "auto"
+    cam_batch_size = args.batch_size if issubclass(extractor_cls, methods.ScoreCAM) else "n/a"
+    print(
+        f"method={args.method} model={args.arch} device={device} input=1x3x{args.size}x{args.size} "
+        f"iterations={args.it} scope={args.scope} weights={args.weights} seed=0 input_batch_size=1 "
+        f"cam_batch_size={cam_batch_size} target_layers={target_layers}"
+    )
+    print(f"samples_ms=[{', '.join(f'{sample:.3f}' for sample in timings_)}]")
+    print(f"median {median:.2f}ms, IQR {q3 - q1:.2f}ms (q1 {q1:.2f}ms, q3 {q3:.2f}ms)")
+    print(f"mean {timings_.mean():.2f}ms, std {timings_.std():.2f}ms")
+
+
+if __name__ == "__main__":
+    main(_build_parser().parse_args())

--- a/tests/test_eval_latency.py
+++ b/tests/test_eval_latency.py
@@ -1,0 +1,74 @@
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from scripts import eval_latency
+
+
+def test_synchronize_dispatch(monkeypatch):
+    calls = []
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda device: calls.append(("cuda", device)))
+    monkeypatch.setattr(torch.mps, "synchronize", lambda: calls.append(("mps", None)))
+
+    eval_latency._synchronize(torch.device("cpu"))
+    eval_latency._synchronize(torch.device("cuda:1"))
+    eval_latency._synchronize(torch.device("mps"))
+
+    assert calls == [("cuda", torch.device("cuda:1")), ("mps", None)]
+
+
+@pytest.mark.parametrize(
+    ("scope", "expected_events"),
+    [
+        ("extractor", ["forward", "sync", "clock", "extract", "sync", "clock"]),
+        ("end-to-end", ["sync", "clock", "forward", "extract", "sync", "clock"]),
+    ],
+)
+def test_timing_scope(scope, expected_events, monkeypatch):
+    events = []
+
+    def forward(_input):
+        events.append("forward")
+        return torch.tensor([[0.0, 1.0]])
+
+    def extractor(_class_idx, _scores, **_kwargs):
+        events.append("extract")
+        return [torch.ones((1, 2, 2))]
+
+    ticks = iter((1.0, 1.25))
+    monkeypatch.setattr(eval_latency, "_synchronize", lambda _device: events.append("sync"))
+    monkeypatch.setattr(eval_latency.time, "perf_counter", lambda: (events.append("clock"), next(ticks))[1])
+
+    eval_latency._time_sample(
+        Mock(side_effect=forward),
+        torch.ones((1, 3, 2, 2)),
+        extractor,
+        None,
+        torch.device("cpu"),
+        scope,
+        {},
+    )
+
+    assert events == expected_events
+
+
+def test_validate_cams_rejects_invalid_output():
+    with pytest.raises(RuntimeError):
+        eval_latency._validate_cams([torch.tensor([[[torch.nan]]])], None)
+    with pytest.raises(RuntimeError):
+        eval_latency._validate_cams([torch.ones((1, 3, 3))], ((1, 2, 2),))
+
+
+@pytest.mark.parametrize(
+    ("argv", "message"),
+    [
+        (("UnknownCAM",), "invalid choice"),
+        (("GradCAM", "--it", "0"), "expected a positive integer"),
+        (("ScoreCAM", "--batch-size", "0"), "expected a positive integer"),
+    ],
+)
+def test_cli_rejects_invalid_values(argv, message, capsys):
+    with pytest.raises(SystemExit):
+        eval_latency._build_parser().parse_args(argv)
+    assert message in capsys.readouterr().err

--- a/tests/test_methods_activation.py
+++ b/tests/test_methods_activation.py
@@ -1,5 +1,6 @@
 import pytest
 import torch
+from torch import nn
 from torchvision.models import get_model
 
 from torchcam.methods import activation
@@ -23,6 +24,25 @@ def _verify_cam(activation_map, output_size):
     assert isinstance(activation_map, torch.Tensor)
     assert activation_map.shape == output_size
     assert not torch.isnan(activation_map).any()
+
+
+def _scorecam_inputs():
+    torch.manual_seed(0)
+    model = nn.Sequential(
+        nn.Conv2d(3, 4, 3, padding=1),
+        nn.ReLU(),
+        nn.Conv2d(4, 5, 3, padding=1),
+        nn.ReLU(),
+        nn.AdaptiveAvgPool2d(1),
+        nn.Flatten(),
+        nn.Linear(5, 3),
+    ).double()
+    model.eval().requires_grad_(False)
+    return model, torch.rand((2, 3, 8, 8), dtype=torch.float64)
+
+
+def _scorecam_kwargs(cam_name, batch_size):
+    return {"batch_size": batch_size, **({} if cam_name == "ScoreCAM" else {"num_samples": 2})}
 
 
 @pytest.mark.parametrize(
@@ -82,22 +102,54 @@ def test_cam_conv1x1(mock_fullyconv_model):
         _verify_cam(extractor(scores[0].argmax().item(), scores)[0], (1, 32, 32))
 
 
-def test_scorecam_restores_state_on_error(mock_img_tensor, monkeypatch):
-    model = get_model("mobilenet_v2", weights=None).train()
-    for p in model.parameters():
-        p.requires_grad_(False)
+@pytest.mark.parametrize("cam_name", ["ScoreCAM", "SSCAM", "ISCAM"])
+@pytest.mark.parametrize("class_idx", [1, [1, 2]])
+def test_scorecam_chunk_parity(cam_name, class_idx):
+    results = []
+    for batch_size in (3, 64):
+        model, input_tensor = _scorecam_inputs()
+        with activation.__dict__[cam_name](
+            model,
+            ["1", "3"],
+            **_scorecam_kwargs(cam_name, batch_size),
+        ) as extractor:
+            scores = model(input_tensor)
+            torch.manual_seed(1)
+            results.append(extractor(class_idx, scores))
 
-    with activation.ScoreCAM(model, "features.16.conv.3", batch_size=8) as extractor:
+    assert [cam.shape for cam in results[0]] == [(2, 8, 8), (2, 8, 8)]
+    assert all(cam.dtype == torch.float64 and cam.device.type == "cpu" for cam in results[0])
+    for chunked, unchunked in zip(*results, strict=True):
+        torch.testing.assert_close(chunked, unchunked)
+
+
+@pytest.mark.parametrize("cam_name", ["ScoreCAM", "SSCAM", "ISCAM"])
+def test_scorecam_preserves_disabled_hooks(cam_name):
+    model, input_tensor = _scorecam_inputs()
+    with activation.__dict__[cam_name](model, ["1", "3"], **_scorecam_kwargs(cam_name, 3)) as extractor:
+        scores = model(input_tensor)
+        extractor.disable_hooks()
+        torch.manual_seed(1)
+        _ = extractor(1, scores)
+        assert not extractor._hooks_enabled
+
+
+@pytest.mark.parametrize("cam_name", ["ScoreCAM", "SSCAM", "ISCAM"])
+def test_scorecam_restores_state_on_error(cam_name, monkeypatch):
+    model, input_tensor = _scorecam_inputs()
+    model.train()
+
+    with activation.__dict__[cam_name](model, ["1", "3"], **_scorecam_kwargs(cam_name, 3)) as extractor:
         extractor.enable_hooks()
-        scores = model(mock_img_tensor)
+        scores = model(input_tensor)
         monkeypatch.setattr(
             extractor,
-            "_get_score_weights",
+            "_masked_input_chunk",
             lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("boom")),
         )
 
         with pytest.raises(RuntimeError):
-            extractor(scores[0].argmax().item(), scores)
+            extractor(1, scores)
 
         assert extractor._hooks_enabled
         assert model.training
@@ -125,6 +177,8 @@ def test_video_cams(
     # Speed up testing by reducing the number of samples
     if isinstance(num_samples, int):
         kwargs["num_samples"] = num_samples
+    if cam_name != "CAM":
+        kwargs["batch_size"] = 3
 
     # Hook the corresponding layer in the model
     with activation.__dict__[cam_name](model, target_layer, **kwargs) as extractor, torch.no_grad():

--- a/torchcam/methods/activation.py
+++ b/torchcam/methods/activation.py
@@ -170,37 +170,57 @@ class ScoreCAM(_CAM):
         if self._hooks_enabled:
             self._input = input_[0].detach().clone()
 
+    def _prepare_masked_inputs(self, activation: Tensor) -> tuple[Tensor, Tensor, Tensor]:
+        """Prepare activation masks and their sample indices.
+
+        Returns:
+            mask source, flattened sample indices and reusable input buffer
+        """
+        batch, channels = activation.shape[:2]
+        sample_indices = torch.arange(batch).repeat_interleave(channels)
+        return (
+            activation.flatten(0, 1).unsqueeze(1),
+            sample_indices,
+            self._input.new_empty((min(self.bs, batch * channels), *self._input.shape[1:])),
+        )
+
+    def _masked_input_chunk(self, masks: Tensor, sample_indices: Tensor, buffer: Tensor, slice_: slice) -> Tensor:
+        model_input = self._input if self._input.shape[0] == 1 else self._input[sample_indices[slice_]]
+        chunk = buffer[: slice_.stop - slice_.start]
+        return torch.mul(masks[slice_], model_input, out=chunk)
+
     @torch.no_grad()
     def _get_score_weights(self, activations: list[Tensor], class_idx: int | list[int]) -> list[Tensor]:
-        b, c = activations[0].shape[:2]
-        # (N * C, I, H, W)
-        scored_inputs = [
-            (act.unsqueeze(2) * self._input.unsqueeze(1)).view(b * c, *self._input.shape[1:]) for act in activations
-        ]
+        prepared_inputs = [self._prepare_masked_inputs(act) for act in activations]
 
         # Initialize weights
         # (N * C)
-        weights = [torch.zeros(b * c, dtype=t.dtype).to(device=t.device) for t in activations]
+        weights = [
+            torch.zeros(act.shape[0] * act.shape[1], dtype=act.dtype).to(device=act.device) for act in activations
+        ]
 
         # (N, M)
         logits = self.model(self._input)
-        idcs = torch.arange(b).repeat_interleave(c)
 
-        for idx, scored_input in enumerate(scored_inputs):
+        for (masks, sample_indices, buffer), weight in zip(prepared_inputs, weights, strict=True):
             # Process by chunk (GPU RAM limitation)
-            for idx_ in range(math.ceil(weights[idx].numel() / self.bs)):
-                slice_ = slice(idx_ * self.bs, min((idx_ + 1) * self.bs, weights[idx].numel()))
+            for idx_ in range(math.ceil(weight.numel() / self.bs)):
+                slice_ = slice(idx_ * self.bs, min((idx_ + 1) * self.bs, weight.numel()))
                 # Get the softmax probabilities of the target class
                 # (*, M)
-                cic = self.model(scored_input[slice_]) - logits[idcs[slice_]]
+                baseline = logits if logits.shape[0] == 1 else logits[sample_indices[slice_]]
+                cic = self.model(self._masked_input_chunk(masks, sample_indices, buffer, slice_)) - baseline
                 if isinstance(class_idx, int):
-                    weights[idx][slice_] = cic[:, class_idx]
+                    weight[slice_] = cic[:, class_idx]
                 else:
-                    target = torch.tensor(class_idx, device=cic.device)[idcs[slice_]]
-                    weights[idx][slice_] = cic.gather(1, target.view(-1, 1)).squeeze(1)
+                    chunk_target = torch.tensor(class_idx, device=cic.device)[sample_indices[slice_]]
+                    weight[slice_] = cic.gather(1, chunk_target.view(-1, 1)).squeeze(1)
 
         # Reshape the weights (N, C)
-        return [torch.softmax(w.view(b, c), -1) for w in weights]
+        return [
+            torch.softmax(weight.view(*activation.shape[:2]), -1)
+            for weight, activation in zip(weights, activations, strict=True)
+        ]
 
     @torch.no_grad()
     def _get_weights(
@@ -304,38 +324,38 @@ class SSCAM(ScoreCAM):
 
     @torch.no_grad()
     def _get_score_weights(self, activations: list[Tensor], class_idx: int | list[int]) -> list[Tensor]:
-        b, c = activations[0].shape[:2]
-
         # Initialize weights
         # (N * C)
-        weights = [torch.zeros(b * c, dtype=t.dtype).to(device=t.device) for t in activations]
+        weights = [
+            torch.zeros(act.shape[0] * act.shape[1], dtype=act.dtype).to(device=act.device) for act in activations
+        ]
 
         # (N, M)
         logits = self.model(self._input)
-        idcs = torch.arange(b).repeat_interleave(c)
 
-        for idx, act in enumerate(activations):
+        for activation, weight in zip(activations, weights, strict=True):
             # Add noise
             for _ in range(self.num_samples):
-                noise = self._distrib.sample(act.size()).to(device=act.device)
-                # (N, C, I, H, W)
-                scored_input = (act + noise).unsqueeze(2) * self._input.unsqueeze(1)
-                # (N * C, I, H, W)
-                scored_input = scored_input.view(b * c, *scored_input.shape[2:])
+                noise = self._distrib.sample(activation.size()).to(device=activation.device)
+                masks, sample_indices, buffer = self._prepare_masked_inputs(activation + noise)
 
                 # Process by chunk (GPU RAM limitation)
-                for idx_ in range(math.ceil(weights[idx].numel() / self.bs)):
-                    slice_ = slice(idx_ * self.bs, min((idx_ + 1) * self.bs, weights[idx].numel()))
+                for idx_ in range(math.ceil(weight.numel() / self.bs)):
+                    slice_ = slice(idx_ * self.bs, min((idx_ + 1) * self.bs, weight.numel()))
                     # Get the softmax probabilities of the target class
-                    cic = self.model(scored_input[slice_]) - logits[idcs[slice_]]
+                    baseline = logits if logits.shape[0] == 1 else logits[sample_indices[slice_]]
+                    cic = self.model(self._masked_input_chunk(masks, sample_indices, buffer, slice_)) - baseline
                     if isinstance(class_idx, int):
-                        weights[idx][slice_] += cic[:, class_idx]
+                        weight[slice_] += cic[:, class_idx]
                     else:
-                        target = torch.tensor(class_idx, device=cic.device)[idcs[slice_]]
-                        weights[idx][slice_] += cic.gather(1, target.view(-1, 1)).squeeze(1)
+                        chunk_target = torch.tensor(class_idx, device=cic.device)[sample_indices[slice_]]
+                        weight[slice_] += cic.gather(1, chunk_target.view(-1, 1)).squeeze(1)
 
         # Reshape the weights (N, C)
-        return [torch.softmax(weight.div_(self.num_samples).view(b, c), -1) for weight in weights]
+        return [
+            torch.softmax(weight.div_(self.num_samples).view(*activation.shape[:2]), -1)
+            for weight, activation in zip(weights, activations, strict=True)
+        ]
 
     def __repr__(self) -> str:  # noqa: D105
         return f"{self.__class__.__name__}(batch_size={self.bs}, num_samples={self.num_samples}, std={self.std})"
@@ -404,35 +424,36 @@ class ISCAM(ScoreCAM):
 
     @torch.no_grad()
     def _get_score_weights(self, activations: list[Tensor], class_idx: int | list[int]) -> list[Tensor]:
-        b, c = activations[0].shape[:2]
-        # (N * C, I, H, W)
-        scored_inputs = [
-            (act.unsqueeze(2) * self._input.unsqueeze(1)).view(b * c, *self._input.shape[1:]) for act in activations
-        ]
+        prepared_inputs = [self._prepare_masked_inputs(act) for act in activations]
 
         # Initialize weights
-        weights = [torch.zeros(b * c, dtype=t.dtype).to(device=t.device) for t in activations]
+        weights = [
+            torch.zeros(act.shape[0] * act.shape[1], dtype=act.dtype).to(device=act.device) for act in activations
+        ]
 
         # (N, M)
         logits = self.model(self._input)
-        idcs = torch.arange(b).repeat_interleave(c)
 
-        for idx, scored_input in enumerate(scored_inputs):
+        for (masks, sample_indices, buffer), weight in zip(prepared_inputs, weights, strict=True):
             coeff = 0.0
             # Process by chunk (GPU RAM limitation)
             for sidx in range(self.num_samples):
                 coeff += (sidx + 1) / self.num_samples
 
                 # Process by chunk (GPU RAM limitation)
-                for idx_ in range(math.ceil(weights[idx].numel() / self.bs)):
-                    slice_ = slice(idx_ * self.bs, min((idx_ + 1) * self.bs, weights[idx].numel()))
+                for idx_ in range(math.ceil(weight.numel() / self.bs)):
+                    slice_ = slice(idx_ * self.bs, min((idx_ + 1) * self.bs, weight.numel()))
                     # Get the softmax probabilities of the target class
-                    cic = self.model(coeff * scored_input[slice_]) - logits[idcs[slice_]]
+                    baseline = logits if logits.shape[0] == 1 else logits[sample_indices[slice_]]
+                    cic = self.model(coeff * self._masked_input_chunk(masks, sample_indices, buffer, slice_)) - baseline
                     if isinstance(class_idx, int):
-                        weights[idx][slice_] += cic[:, class_idx]
+                        weight[slice_] += cic[:, class_idx]
                     else:
-                        target = torch.tensor(class_idx, device=cic.device)[idcs[slice_]]
-                        weights[idx][slice_] += cic.gather(1, target.view(-1, 1)).squeeze(1)
+                        chunk_target = torch.tensor(class_idx, device=cic.device)[sample_indices[slice_]]
+                        weight[slice_] += cic.gather(1, chunk_target.view(-1, 1)).squeeze(1)
 
         # Reshape the weights (N, C)
-        return [torch.softmax(weight.div_(self.num_samples).view(b, c), -1) for weight in weights]
+        return [
+            torch.softmax(weight.div_(self.num_samples).view(*activation.shape[:2]), -1)
+            for weight, activation in zip(weights, activations, strict=True)
+        ]


### PR DESCRIPTION
## Summary

- makes CUDA/MPS benchmark timing accelerator-correct and adds reproducible raw samples plus median/IQR
- creates only the current ScoreCAM-family masked-input chunk in one reusable buffer, preserving public APIs, math, and `batch_size=32`
- broadcasts the single baseline-logit row for batch 1 instead of gathering identical rows per chunk
- constructs untrained benchmark models directly on MPS to avoid a transient host-memory peak
- exposes the existing masked-input batch size in Streamlit without a platform-specific default

## CPU/MPS gate

Fixed seed 0, `weights=none`, ResNet-18 `layer4`, input batch 1, `1x3x224x224`, extraction scope. Default batch 32 uses two fresh base and two fresh candidate processes in `A/B/B/A` order; other batch sizes use fresh paired processes.

| Device | Batch | Base median / IQR | Candidate median / IQR | Latency change | Base RSS | Candidate RSS | RSS change |
|---|---:|---:|---:|---:|---:|---:|---:|
| cpu | 8 | 6387.608 / 141.121 ms | 6236.016 / 153.622 ms | -2.373% | 1161.1 MiB | 887.5 MiB | -23.566% |
| cpu | 16 | 10019.192 / 471.740 ms | 8975.760 / 636.268 ms | -10.414% | 1216.8 MiB | 896.1 MiB | -26.358% |
| cpu | 32 | 8028.218 / 574.927 ms | 8225.598 / 422.498 ms | +2.459% | 1410.2 MiB | 1098.3 MiB | -22.117% |
| mps | 8 | 788.978 / 14.802 ms | 755.251 / 25.558 ms | -4.275% | 491.3 MiB | 465.2 MiB | -5.318% |
| mps | 16 | 737.585 / 7.108 ms | 709.753 / 4.367 ms | -3.773% | 491.3 MiB | 468.1 MiB | -4.729% |
| mps | 32 | 744.445 / 7.948 ms | 724.983 / 11.549 ms | -2.614% | 490.2 MiB | 466.7 MiB | -4.805% |

All 12 CPU/MPS ScoreCAM/SSCAM/ISCAM parity cases were bit-for-bit exact for scalar/list classes, batch 2, and two target layers. CPU process RSS clears the original 15% threshold. MPS process RSS improves about 5%; it is whole-process RSS on Apple unified memory, not a true MPS allocator peak, so no GPU-memory claim is made. CUDA remains explicitly unverified.

<details>
<summary>Raw interleaved ScoreCAM samples</summary>

| Device | Batch | Variant | Raw samples (ms) | Median | Peak RSS |
|---|---:|---|---|---:|---:|
| cpu | 32 | base | 8088.058, 7965.300, 8691.977 | 8088.058 ms | 1383.2 MiB |
| cpu | 32 | candidate | 8242.527, 8115.384, 8208.669 | 8208.669 ms | 1101.2 MiB |
| cpu | 32 | candidate | 9307.186, 8667.428, 7521.324 | 8667.428 ms | 1095.5 MiB |
| cpu | 32 | base | 8905.142, 7968.379, 7080.565 | 7968.379 ms | 1437.3 MiB |
| cpu | 8 | base | 6183.466, 6387.608, 6465.709 | 6387.608 ms | 1161.1 MiB |
| cpu | 8 | candidate | 6171.008, 6236.016, 6478.251 | 6236.016 ms | 887.5 MiB |
| cpu | 16 | candidate | 8908.076, 8975.760, 10180.612 | 8975.760 ms | 896.1 MiB |
| cpu | 16 | base | 10019.192, 10297.766, 9354.285 | 10019.192 ms | 1216.8 MiB |
| mps | 32 | base | 840.436, 744.601, 741.907, 751.122, 743.266, 736.729, 743.011 | 743.266 ms | 489.7 MiB |
| mps | 32 | candidate | 768.842, 725.667, 724.299, 726.215, 735.533, 720.275, 719.255 | 725.667 ms | 463.9 MiB |
| mps | 32 | candidate | 758.358, 723.875, 732.627, 729.415, 717.383, 720.275, 719.189 | 723.875 ms | 469.4 MiB |
| mps | 32 | base | 833.466, 744.288, 748.503, 746.441, 741.400, 754.659, 742.355 | 746.441 ms | 490.7 MiB |
| mps | 8 | base | 875.770, 772.110, 778.311, 779.756, 795.607, 792.063, 788.978 | 788.978 ms | 491.3 MiB |
| mps | 8 | candidate | 855.681, 748.798, 744.868, 760.618, 784.165, 755.251, 725.006 | 755.251 ms | 465.2 MiB |
| mps | 16 | candidate | 775.274, 709.753, 706.605, 710.085, 706.135, 711.679, 706.425 | 709.753 ms | 468.1 MiB |
| mps | 16 | base | 1309.311, 734.663, 737.285, 741.755, 737.585, 736.831, 746.577 | 737.585 ms | 491.3 MiB |

</details>

## Environment and validation

- Apple M3 Pro, macOS 15.7.7 arm64, Python 3.11.13, Torch 2.13.0, TorchVision 0.28.0, five Torch CPU threads
- commits: `25ce8df` benchmark correction; `fd0fef7` ScoreCAM-family memory optimization
- focused benchmark tests: `7 passed`
- focused ScoreCAM-family parity/state tests: `16 passed`
- full suite: `187 passed, 2 skipped`, `99%` coverage; coverage XML and `--durations=20`
- `rtk make quality`: Ruff check/format, ty, and dependency-sync checks passed
- CPU/MPS parity harness: bit-for-bit exact
- headless Streamlit health: HTTP 200 `ok`
- `rtk git diff --check`: passed; final worktree clean

Exact benchmark command shape:

```shell
/usr/bin/time -l .venv/bin/python scripts/eval_latency.py ScoreCAM --arch resnet18 --device DEVICE --weights none --scope extractor --it ITERATIONS --target-layer layer4 --batch-size 8|16|32
```
