### PR TITLE
build(deps): modernize support and docs security

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,11 +37,8 @@ classifiers = [
 dependencies = [
     # cf. https://github.com/frgfm/torch-cam/discussions/148
     "torch>=2.0.0,<3.0.0",
-    "numpy>=1.17.2,<2.0.0",
-    # cf. https://github.com/advisories/GHSA-98vv-pw6r-q6q4
-    # cf. https://github.com/pytorch/vision/issues/4934
-    # https://github.com/frgfm/Holocron/security/dependabot/5
-    "Pillow>=8.4.0,!=9.2.0",
+    "numpy>=1.26.4,<3.0.0",
+    "Pillow>=9.3.0",
     "matplotlib>=3.7.0,<4.0.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-    "requests>=2.20.0,<3.0.0",
     "torchvision>=0.24.0,<1.0.0",
     "pytest==9.1.1",
     "pytest-cov==7.1.0",
@@ -71,7 +70,6 @@ demo = [
     "torchvision>=0.15.0,<1.0.0",
 ]
 scripts = [
-    "requests>=2.20.0,<3.0.0",
     "torchvision>=0.15.0,<1.0.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,12 +62,12 @@ quality = [
 docs = [
     # cf. https://github.com/mkdocs/catalog
     "mkdocs==1.6.1",
-    "mkdocs-material[imaging]==9.6.22",
-    "mkdocstrings[python]==0.30.1",
-    "griffe-typingdoc==0.3.0",
+    "mkdocs-material[imaging]==9.7.7",
+    "mkdocstrings[python]==1.0.6",
+    "griffe-typingdoc==0.3.1",
     # "termynal==0.13.1",
     # "mkdocs-swagger-ui-tag==0.7.2",
-    "mkdocs-llmstxt==0.4.0",
+    "mkdocs-llmstxt==0.5.0",
 ]
 demo = [
     "streamlit>=1.61.0,<2.0.0",

--- a/scripts/cam_example.py
+++ b/scripts/cam_example.py
@@ -11,9 +11,9 @@ import argparse
 import math
 from functools import partial
 from io import BytesIO
+from urllib.request import Request, urlopen
 
 import matplotlib.pyplot as plt
-import requests
 import torch
 from PIL import Image
 from torchvision.models import get_model, get_model_weights
@@ -46,6 +46,17 @@ def resolve_transformer_config(model, target_layer):
     return target_layer, reshape_transform
 
 
+def _load_image(img_path):
+    if img_path.startswith(("http://", "https://")):
+        request = Request(  # noqa: S310
+            img_path,
+            headers={"User-Agent": "TorchCAM (+https://github.com/frgfm/torch-cam)"},
+        )
+        with urlopen(request, timeout=5) as response:  # noqa: S310  # nosec B310
+            img_path = BytesIO(response.read())
+    return Image.open(img_path, mode="r").convert("RGB")
+
+
 def main(args):  # noqa: PLR0912
     if args.device is None:
         args.device = "cuda:0" if torch.cuda.is_available() else "cpu"
@@ -60,8 +71,7 @@ def main(args):  # noqa: PLR0912
         p.requires_grad_(False)
 
     # Image
-    img_path = BytesIO(requests.get(args.img, timeout=5).content) if args.img.startswith("http") else args.img
-    pil_img = Image.open(img_path, mode="r").convert("RGB")
+    pil_img = _load_image(args.img)
     preprocess = weights.transforms()
 
     # Preprocess image

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,32 +1,17 @@
-from io import BytesIO
-
 import pytest
-import requests
 import torch
-from PIL import Image
 from torch import nn
-from torchvision.transforms.functional import normalize, resize, to_tensor
+from torchvision.transforms.functional import normalize
 
 
 @pytest.fixture(scope="session")
 def mock_img_tensor():
-    try:
-        # Get a dog image
-        url = "https://www.woopets.fr/assets/races/000/066/big-portrait/border-collie.jpg"
-        response = requests.get(url, timeout=5)
-
-        # Forward an image
-        pil_img = Image.open(BytesIO(response.content), mode="r").convert("RGB")
-        img_tensor = normalize(
-            to_tensor(resize(pil_img, (224, 224))),
-            [0.485, 0.456, 0.406],
-            [0.229, 0.224, 0.225],
-        ).unsqueeze(0)
-    except ConnectionError:
-        img_tensor = torch.rand((1, 3, 224, 224))
-
-    img_tensor.requires_grad_(True)
-    return img_tensor
+    generator = torch.Generator().manual_seed(0)
+    return normalize(
+        torch.rand((1, 3, 224, 224), generator=generator),
+        [0.485, 0.456, 0.406],
+        [0.229, 0.224, 0.225],
+    ).requires_grad_(True)
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_cam_example.py
+++ b/tests/test_cam_example.py
@@ -1,0 +1,43 @@
+from contextlib import nullcontext
+from io import BytesIO
+from unittest.mock import Mock
+
+import pytest
+from PIL import Image, UnidentifiedImageError
+
+from scripts import cam_example
+
+
+def test_load_image_from_local_path_and_url(tmp_path, monkeypatch):
+    image_path = tmp_path / "image.png"
+    Image.new("RGB", (4, 4), color="red").save(image_path)
+    payload = image_path.read_bytes()
+
+    def fake_urlopen(request, timeout):
+        assert request.full_url == "https://example.com/image.png"
+        assert request.get_header("User-agent").startswith("TorchCAM")
+        assert timeout == 5
+        return BytesIO(payload)
+
+    monkeypatch.setattr(cam_example, "urlopen", fake_urlopen)
+
+    local_image = cam_example._load_image(str(image_path))
+    url_image = cam_example._load_image("https://example.com/image.png")
+    assert local_image.mode == url_image.mode == "RGB"
+    assert local_image.size == url_image.size == (4, 4)
+
+
+def test_load_image_propagates_read_errors(monkeypatch):
+    response = Mock()
+    response.read.side_effect = OSError("read failed")
+    monkeypatch.setattr(cam_example, "urlopen", lambda *_args, **_kwargs: nullcontext(response))
+
+    with pytest.raises(OSError, match="read failed"):
+        cam_example._load_image("https://example.com/image.png")
+
+
+def test_load_image_rejects_corrupt_payload(monkeypatch):
+    monkeypatch.setattr(cam_example, "urlopen", lambda *_args, **_kwargs: BytesIO(b"not an image"))
+
+    with pytest.raises(UnidentifiedImageError):
+        cam_example._load_image("https://example.com/image.png")


### PR DESCRIPTION
# What does this PR do?

Modernizes TorchCAM's supported dependency contract and removes the vulnerable documentation resolution identified by the repository audit.

- upgrades the coupled MkDocs dependency group without changing the documentation framework
- supports NumPy 2 and publishes binary-realistic NumPy/Pillow floors
- removes direct Requests usage from tests and scripts; tests now use a deterministic ImageNet-normalized tensor and the example uses urllib
- preserves Python >=3.11,<4 and the public Python API

## Dependency evidence

| Dependency | Before | After / candidate resolution |
|---|---:|---:|
| mkdocs | 1.6.1 | 1.6.1 |
| mkdocs-material[imaging] | 9.6.22 | 9.7.7 |
| mkdocstrings[python] | 0.30.1 | 1.0.6 |
| griffe-typingdoc | 0.3.0 | 0.3.1 |
| mkdocs-llmstxt | 0.4.0 | 0.5.0 |
| mkdocstrings-python | 2.0.7 | 2.0.7 |
| NumPy contract | >=1.17.2,<2.0.0 | >=1.26.4,<3.0.0 |
| NumPy resolved (Py3.11 all extras) | 1.26.4 | 2.4.6 |
| Pillow contract | >=8.4.0,!=9.2.0 | >=9.3.0 |
| Pillow resolved | 11.3.0 | 12.3.0 |
| pymdown-extensions resolved | 10.21.3 | 11.0.1 |
| Requests in test/scripts extras | direct dependency | removed |

NumPy 1.26.4 is the tested lower edge. A NumPy-2-only floor is not declared because the still-supported Torch 2.0.0 / Matplotlib 3.7.0 floor fails against NumPy 2.0.0 with NumPy ABI import errors.

Requests remains transitively present in the all-extras environment through Material 9.7.7; this PR removes only the direct test/scripts dependency and leaves the separate GitHub label helper unchanged.

### Audit

| Environment | Packages | Vulnerable packages | Advisory records |
|---|---:|---:|---:|
| current-main baseline | 104 | 2 | 27 (Pillow 25, pymdown-extensions 2) |
| candidate all-extras/docs | 102 | 0 | 0 |

Candidate: Pillow 12.3.0 and pymdown-extensions 11.0.1 each report zero advisories.

<details>
<summary>Complete candidate all-extras/docs resolution (102 packages)</summary>

~~~text
altair==6.2.2
anyio==4.14.2
attrs==26.1.0
babel==2.18.0
backrefs==8.0
beautifulsoup4==4.15.0
blinker==1.9.0
cairocffi==1.7.1
cairosvg==2.9.0
certifi==2026.7.22
cffi==2.1.1
charset-normalizer==3.5.1
click==8.4.2
colorama==0.4.6
contourpy==1.3.3
coverage==7.15.4
cssselect2==0.9.0
cycler==0.12.1
defusedxml==0.7.1
filelock==3.32.3
fonttools==4.63.0
fsspec==2026.7.0
ghp-import==2.1.0
griffe-typingdoc==0.3.1
griffelib==2.2.0
h11==0.16.0
httptools==0.8.0
idna==3.19
iniconfig==2.3.0
itsdangerous==2.2.0
jinja2==3.1.6
jsonschema==4.26.0
jsonschema-specifications==2025.9.1
kiwisolver==1.5.0
markdown==3.10.3
markdown-it-py==3.0.0
markdownify==1.2.3
markupsafe==3.0.3
matplotlib==3.11.1
mdformat==0.7.22
mdformat-tables==1.0.0
mdurl==0.1.2
mergedeep==1.3.4
mkdocs==1.6.1
mkdocs-autorefs==1.4.4
mkdocs-get-deps==0.2.2
mkdocs-llmstxt==0.5.0
mkdocs-material==9.7.7
mkdocs-material-extensions==1.3.1
mkdocstrings==1.0.6
mkdocstrings-python==2.0.7
mpmath==1.3.0
narwhals==2.24.0
networkx==3.6.1
numpy==2.4.6
packaging==26.3
paginate==0.5.7
pandas==3.0.5
pathspec==1.1.1
pillow==12.3.0
platformdirs==4.11.3
pluggy==1.6.0
prek==0.4.11
protobuf==7.35.1
pyarrow==25.0.1
pycparser==3.0
pydeck==0.9.3
pygments==2.21.0
pymdown-extensions==11.0.1
pyparsing==3.3.2
pytest==9.1.1
pytest-cov==7.1.0
pytest-pretty==1.3.0
python-dateutil==2.9.0.post0
python-multipart==0.0.32
pyyaml==6.0.3
pyyaml-env-tag==1.1
referencing==0.37.0
requests==2.34.2
rich==15.0.0
rpds-py==2026.6.3
ruff==0.16.0
setuptools==84.0.0
six==1.17.0
soupsieve==2.9.2
starlette==1.6.0
streamlit==1.62.0
sympy==1.14.0
tinycss2==1.5.1
toml==0.10.2
torch==2.13.0
torchcam==0.5.0.dev0
torchvision==0.28.0
ty==0.0.65
types-pillow==10.2.0.20240822
typing-extensions==4.16.0
urllib3==2.7.0
uvicorn==0.52.4
watchdog==6.0.0
wcwidth==0.8.2
webencodings==0.6.1
websockets==16.1.1
~~~
</details>

## Validation

- Python 3.11 / NumPy 1.26.4: 219 passed, 2 skipped, 99% coverage; pytest 133.00s, wall 145.2s.
- Python 3.11 / NumPy 2.4.6: 219 passed, 2 skipped, 99% coverage; pytest 143.50s, wall 155.3s.
- Both full suites ran with HTTP(S)/ALL proxies pointed at a closed loopback port.
- Focused no-network check: Requests absent from the test environment; 23 loader/fixture tests passed in 1.44s.
- Python 3.12 / NumPy 2.5.2: core import and RGB overlay smoke passed with Torch 2.13.0.
- Lowest-direct Python 3.11: Torch 2.0.0, NumPy 1.26.4, Pillow 9.3.0, Matplotlib 3.7.0; import/overlay smoke passed.
- make quality: Ruff lint/format, ty, and dependency synchronization passed.
- make install-docs and make build-docs passed.
- Strict MkDocs build passed; no Pillow inventory HTTP 429 occurred.
- Baseline/candidate sites both contain 93 files and identical 17-entry navigation. The only path changes are eight version-hashed Material JS/CSS assets. API reference pages, llms.txt, and llms-full.txt are present and non-empty.
- Local and loopback-HTTP example inputs both produced saved LayerCAM output. The current default external image URL also passed with an explicit TorchCAM User-Agent. HTTP 404 propagated as urllib.error.HTTPError; corrupt bytes propagated as PIL.UnidentifiedImageError.
- External build: 41,085-byte wheel and 45,691-byte sdist. Fresh wheel install/import passed from site-packages.
- git diff --check for the branch and working tree passed; no uv.lock was created; final status was clean.

## Evidence boundaries

- NumPy 2 is a support/ecosystem change; no CAM extraction speedup is claimed.
- CUDA and MPS hardware gates were not run because this PR changes dependency metadata and input plumbing, not runtime algorithms.
- URL behavior was verified through both a real loopback HTTP server and the current default external image host; future host availability remains outside project control.
- Pillow inventories responded during both baseline and candidate strict builds; there is no unresolved external HTTP failure.
- GitHub Actions results are pending at PR creation.

## Before submitting

- [x] Read and followed the contribution guidelines.
- [x] Documentation structure and strict builds were validated; no documentation content change is required.
- [x] Added focused loader tests and ran the complete suite on NumPy 1 and 2.

