### PR TITLE
ci: shorten feedback loops and update developer tooling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,14 +31,17 @@ updates:
       interval: "daily"
       time: "08:00"
     allow:
-      # Safe updates
+      - dependency-name: "mkdocs*"
+      - dependency-name: "griffe*"
       - dependency-name: "ruff"
       - dependency-name: "ty"
       - dependency-name: "prek"
-      - dependency-name: "pytest"
-      - dependency-name: "pytest-cov"
-      - dependency-name: "pytest-pretty"
+      - dependency-name: "pytest*"
     groups:
+      docs:
+        patterns:
+          - "mkdocs*"
+          - "griffe*"
       quality:
         patterns:
           - "ruff"

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -24,7 +24,7 @@ concurrency:
 
 env:
   PYTHON_VERSION: "3.11"
-  UV_VERSION: "0.12.0"  # pinned for reproducible installs across all jobs
+  UV_VERSION: "0.12.5"  # pinned for reproducible installs across all jobs
 
 jobs:
   build:
@@ -35,7 +35,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v10.0.1
         with:
           version: ${{ env.UV_VERSION }}
           activate-environment: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.11"
-  UV_VERSION: "0.12.0"
+  UV_VERSION: "0.12.5"
 
 jobs:
   build:
@@ -20,7 +20,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v10.0.1
         with:
           version: ${{ env.UV_VERSION }}
           activate-environment: true
@@ -44,7 +44,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v10.0.1
         with:
           version: ${{ env.UV_VERSION }}
           activate-environment: true

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -21,7 +21,7 @@ on:
     types: [published]
 
 env:
-  UV_VERSION: "0.12.0"
+  UV_VERSION: "0.12.5"
   PYTHON_VERSION: "3.11"
 
 
@@ -42,7 +42,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v10.0.1
         with:
           version: ${{ env.UV_VERSION }}
           activate-environment: true
@@ -63,7 +63,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v10.0.1
         with:
           version: ${{ env.UV_VERSION }}
           activate-environment: true
@@ -105,7 +105,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v10.0.1
         with:
           version: ${{ env.UV_VERSION }}
       - name: Run dependency sync checker
@@ -120,7 +120,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v10.0.1
         with:
           version: ${{ env.UV_VERSION }}
           activate-environment: true
@@ -170,7 +170,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v10.0.1
         with:
           version: ${{ env.UV_VERSION }}
       - name: Build the package
@@ -192,7 +192,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v10.0.1
         with:
           version: ${{ env.UV_VERSION }}
       - name: Set package version
@@ -226,7 +226,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v10.0.1
         with:
           version: ${{ env.UV_VERSION }}
       - name: Install package

--- a/.github/workflows/page-build.yml
+++ b/.github/workflows/page-build.yml
@@ -4,7 +4,6 @@ on:
 
 env:
   PYTHON_VERSION: "3.11"
-  UV_VERSION: "0.12.0"
 
 jobs:
   check-gh-pages:

--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.11"
-  UV_VERSION: "0.12.0"
+  UV_VERSION: "0.12.5"
 
 jobs:
   is-properly-labeled:
@@ -19,7 +19,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v10.0.1
         with:
           version: ${{ env.UV_VERSION }}
       - name: Install requests

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.11"
-  UV_VERSION: "0.12.0"
+  UV_VERSION: "0.12.5"
 
 
 jobs:
@@ -22,7 +22,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v10.0.1
         with:
           version: ${{ env.UV_VERSION }}
       - name: Install dependencies
@@ -41,7 +41,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v10.0.1
         with:
           version: ${{ env.UV_VERSION }}
       - name: Install dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,10 +50,9 @@ test = [
     "pytest-pretty==1.3.0",
 ]
 quality = [
-    "ruff==0.16.0",
-    "ty==0.0.65",
-    "types-Pillow",
-    "prek==0.4.11",
+    "ruff==0.16.3",
+    "ty==0.0.73",
+    "prek==0.4.14",
 ]
 docs = [
     # cf. https://github.com/mkdocs/catalog

--- a/tests/test_methods_activation.py
+++ b/tests/test_methods_activation.py
@@ -35,7 +35,7 @@ def _verify_cam(activation_map, output_size):
     # Simple verifications
     assert isinstance(activation_map, torch.Tensor)
     assert activation_map.shape == output_size
-    assert not torch.isnan(activation_map).any()
+    assert torch.isfinite(activation_map).all()
 
 
 def _scorecam_inputs():
@@ -58,53 +58,38 @@ def _scorecam_kwargs(cam_name, batch_size):
 
 
 @pytest.mark.parametrize(
-    (
-        "cam_name",
-        "target_layer",
-        "fc_layer",
-        "num_samples",
-        "output_size",
-        "batch_size",
-    ),
+    ("fc_layer", "batch_size"),
     [
-        ("CAM", None, None, None, (7, 7), 1),
-        ("CAM", None, None, None, (7, 7), 2),
-        ("CAM", None, "classifier.1", None, (7, 7), 1),
-        ("CAM", None, lambda m: m.classifier[1], None, (7, 7), 1),
-        ("ScoreCAM", "features.16.conv.3", None, None, (7, 7), 1),
-        ("ScoreCAM", lambda m: m.features[16].conv[3], None, None, (7, 7), 1),
-        ("SSCAM", "features.16.conv.3", None, 4, (7, 7), 1),
-        ("ISCAM", "features.16.conv.3", None, 4, (7, 7), 1),
+        (None, 1),
+        (None, 2),
+        ("classifier.1", 1),
+        (lambda m: m.classifier[1], 1),
     ],
 )
-def test_img_cams(
-    cam_name,
-    target_layer,
-    fc_layer,
-    num_samples,
-    output_size,
-    batch_size,
-    mock_img_tensor,
-):
+def test_img_cams(fc_layer, batch_size, mock_img_tensor):
     model = get_model("mobilenet_v2", weights=None).eval()
     for p in model.parameters():
         p.requires_grad_(False)
     kwargs = {}
-    # Speed up testing by reducing the number of samples
-    if isinstance(num_samples, int):
-        kwargs["num_samples"] = num_samples
-
     if fc_layer is not None:
         kwargs["fc_layer"] = fc_layer(model) if callable(fc_layer) else fc_layer
 
-    target_layer = target_layer(model) if callable(target_layer) else target_layer
     # Hook the corresponding layer in the model
-    with activation.__dict__[cam_name](model, target_layer, **kwargs) as extractor, torch.no_grad():
+    with activation.CAM(model, **kwargs) as extractor, torch.no_grad():
         scores = model(mock_img_tensor.repeat((batch_size,) + (1,) * (mock_img_tensor.ndim - 1)))
         # Use the hooked data to compute activation map
-        _verify_cam(extractor(scores[0].argmax().item(), scores)[0], (batch_size, *output_size))
+        _verify_cam(extractor(scores[0].argmax().item(), scores)[0], (batch_size, 7, 7))
         # Multiple class indices
-        _verify_cam(extractor(list(range(batch_size)), scores)[0], (batch_size, *output_size))
+        _verify_cam(extractor(list(range(batch_size)), scores)[0], (batch_size, 7, 7))
+
+
+def test_scorecam_torchvision_integration():
+    model = get_model("mobilenet_v2", weights=None).eval().requires_grad_(False)
+    input_tensor = torch.ones((1, 3, 16, 16))
+
+    with activation.ScoreCAM(model, model.features[1].conv[2]) as extractor, torch.no_grad():
+        scores = model(input_tensor)
+        _verify_cam(extractor(scores[0].argmax().item(), scores)[0], (1, 8, 8))
 
 
 def test_cam_conv1x1(mock_fullyconv_model):
@@ -130,7 +115,9 @@ def test_scorecam_chunk_parity(cam_name, class_idx):
             results.append(extractor(class_idx, scores))
 
     assert [cam.shape for cam in results[0]] == [(2, 8, 8), (2, 8, 8)]
-    assert all(cam.dtype == torch.float64 and cam.device.type == "cpu" for cam in results[0])
+    assert all(
+        cam.dtype == torch.float64 and cam.device.type == "cpu" and torch.isfinite(cam).all() for cam in results[0]
+    )
     for chunked, unchunked in zip(*results, strict=True):
         torch.testing.assert_close(chunked, unchunked)
 


### PR DESCRIPTION
## Summary

- update Ruff to 0.16.3, prek to 0.4.14, ty to 0.0.73, and remove redundant `types-Pillow`
- fix the two tensor-count assignments surfaced by ty without suppressions
- move ScoreCAM-family unit coverage to the existing deterministic tiny CNN while retaining one MobileNetV2 integration case
- update uv CI pins and keep Dependabot maintenance scoped to grouped docs, quality, and test updates

## Base dependency

Based on current `main` after #422 and #426, including the Pillow/docs and network-free fixture contract.

## Test-suite feedback

Same Apple M3 Pro, Python 3.11.13, branch coverage enabled:

| | Before | After |
|---|---:|---:|
| Full-suite wall time | 150.56s | 9.39s |
| Tests | 231 passed, 2 skipped | 228 passed, 2 skipped |
| Lines | 1118/1135 | 1118/1135 |
| Branches | 412/424 | 412/424 |
| Total coverage | 98.1398% | 98.1398% |

Default `make test`: 228 passed, 2 skipped in 7.03s.

The retained TorchVision case uses MobileNetV2 with `weights=None`, a deterministic 16x16 input, and the early 16-channel `features[1].conv[2]` layer. ScoreCAM, SSCAM, and ISCAM scalar/list, multi-layer, chunk parity, dtype/device, finite-output, and state-restoration coverage remains on the seeded tiny CNN introduced by #425.

## Tool and workflow validation

- `make quality`
- `make precommit`
- `make build`
- `make install-docs build-docs`
- `make install-demo` and `uv run python demo/smoke.py`
- `make install-test` and `make test`
- ty with no external Pillow stub
- ty with `types-Pillow==10.2.0.20240822` temporarily overlaid
- built-wheel install/import smokes on Python 3.11, 3.12, 3.13, and 3.14
- Dependabot v2 SchemaStore validation
- dependency synchronization
- `rtk git diff --check`
- clean `rtk git status --short`

`astral-sh/setup-uv` is pinned to the current immutable v10.0.1 release tag; the project uv version is 0.12.5. `JamesIves/github-pages-deploy-action` was already current at v4.9.0 and is unchanged.

GitHub Actions results are pending. The `pr-merged` workflow and authoritative Dependabot service behavior cannot execute before merge; this PR does not merge itself.
